### PR TITLE
Update version of jackson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <version.dc-core>2.1.0</version.dc-core>
     <version.geojson>1.8</version.geojson>
     <version.guava>23.0</version.guava>
-    <version.jackson>2.9.0</version.jackson>
+    <version.jackson>2.9.7</version.jackson>
     <version.jacoco-maven-plugin>0.7.9</version.jacoco-maven-plugin>
     <version.jsonassert>1.5.0</version.jsonassert>
     <version.junit>4.12</version.junit>


### PR DESCRIPTION
This PR updates the version of `jackson` dependency and fixes CVE-2018-7489.