### PR TITLE
Add auto-formatting via google style

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,8 @@
 
     <!-- plugins -->
     <version.jacoco-maven-plugin>0.8.5</version.jacoco-maven-plugin>
-    <version.maven-checkstyle-plugin>3.1.0</version.maven-checkstyle-plugin>
     <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
+    <version.maven-fmt-plugin>2.9</version.maven-fmt-plugin>
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
     <version.maven-javadoc-plugin>3.1.1</version.maven-javadoc-plugin>
     <version.maven-source-plugin>3.2.1</version.maven-source-plugin>
@@ -162,6 +162,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>${version.maven-fmt-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${version.spotbugs-maven-plugin}</version>
@@ -178,27 +190,6 @@
         </configuration>
         <executions>
           <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${version.maven-checkstyle-plugin}</version>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <configuration>
-              <configLocation>https://raw.githubusercontent.com/dbmdz/development/master/code-quality/checkstyle.xml</configLocation>
-              <encoding>UTF-8</encoding>
-              <consoleOutput>true</consoleOutput>
-              <failsOnError>true</failsOnError>
-              <linkXRef>false</linkXRef>
-            </configuration>
             <goals>
               <goal>check</goal>
             </goals>

--- a/src/main/java/de/digitalcollections/iiif/model/GenericService.java
+++ b/src/main/java/de/digitalcollections/iiif/model/GenericService.java
@@ -7,18 +7,18 @@ import java.net.URI;
 /**
  * A generic service with an identifier and a profile.
  *
- * Only for unknown services, please check if one of these matches your use case instead:
- * - {@link de.digitalcollections.iiif.model.image.ImageService}
- * - {@link de.digitalcollections.iiif.model.search.ContentSearchService}
- * - {@link de.digitalcollections.iiif.model.search.AutocompleteService}
- * - {@link de.digitalcollections.iiif.model.annex.PhysicalDimensionsService}
- * - {@link de.digitalcollections.iiif.model.annex.GeoService}
+ * <p>Only for unknown services, please check if one of these matches your use case instead: -
+ * {@link de.digitalcollections.iiif.model.image.ImageService} - {@link
+ * de.digitalcollections.iiif.model.search.ContentSearchService} - {@link
+ * de.digitalcollections.iiif.model.search.AutocompleteService} - {@link
+ * de.digitalcollections.iiif.model.annex.PhysicalDimensionsService} - {@link
+ * de.digitalcollections.iiif.model.annex.GeoService}
  */
 public class GenericService extends Service {
 
   @JsonCreator
-  public GenericService(@JsonProperty("@context") URI context,
-                        @JsonProperty("@id") String identifier) {
+  public GenericService(
+      @JsonProperty("@context") URI context, @JsonProperty("@id") String identifier) {
     super(context, identifier);
   }
 

--- a/src/main/java/de/digitalcollections/iiif/model/ImageContent.java
+++ b/src/main/java/de/digitalcollections/iiif/model/ImageContent.java
@@ -11,14 +11,15 @@ import java.net.URI;
 /**
  * An image resource.
  *
- * This entity is what is contained in the "resource" field of annotations with motivation "sc:painting":
- * http://iiif.io/api/presentation/2.1/#image-resources
+ * <p>This entity is what is contained in the "resource" field of annotations with motivation
+ * "sc:painting": http://iiif.io/api/presentation/2.1/#image-resources
  */
 public class ImageContent extends Resource<ImageContent> {
 
   public static final String TYPE = "dctypes:Image";
 
-  // We sometimes want to set this to null during serialization, hence the copy in an instance variable
+  // We sometimes want to set this to null during serialization, hence the copy in an instance
+  // variable
   @SuppressWarnings("checkstyle:membername")
   @JsonIgnore
   public String _type = TYPE;
@@ -31,7 +32,8 @@ public class ImageContent extends Resource<ImageContent> {
   @JsonCreator
   public ImageContent(@JsonProperty("@id") String identifier) {
     super(identifier);
-    // Since the image ID is supposed to resolve to a real image, we can try guessing the format from it
+    // Since the image ID is supposed to resolve to a real image, we can try guessing the format
+    // from it
     this.setFormat(MimeType.fromURI(this.getIdentifier()));
   }
 

--- a/src/main/java/de/digitalcollections/iiif/model/MetadataEntry.java
+++ b/src/main/java/de/digitalcollections/iiif/model/MetadataEntry.java
@@ -8,8 +8,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 /**
  * An entry in a IIIF resource's "metadata" list.
  *
- * Consists of a label and a value, both of which can be multi-valued and multi-lingual (see {@link PropertyValue}.
- * The value should be either simple HTML, including links and text markup, or plain text, and the label should be plain text.
+ * <p>Consists of a label and a value, both of which can be multi-valued and multi-lingual (see
+ * {@link PropertyValue}. The value should be either simple HTML, including links and text markup,
+ * or plain text, and the label should be plain text.
  */
 @JsonPropertyOrder({"label", "value"})
 public class MetadataEntry {
@@ -18,8 +19,8 @@ public class MetadataEntry {
   private PropertyValue value;
 
   @JsonCreator
-  public MetadataEntry(@JsonProperty("label") PropertyValue label,
-                       @JsonProperty("value") PropertyValue value) {
+  public MetadataEntry(
+      @JsonProperty("label") PropertyValue label, @JsonProperty("value") PropertyValue value) {
     this.label = label;
     this.value = value;
   }
@@ -49,7 +50,7 @@ public class MetadataEntry {
 
   @Override
   public String toString() {
-    return String.format("MetadataEntry(label=[%s],value=[%s]",
-                         getLabel().toString(), getValue().toString());
+    return String.format(
+        "MetadataEntry(label=[%s],value=[%s]", getLabel().toString(), getValue().toString());
   }
 }

--- a/src/main/java/de/digitalcollections/iiif/model/ModelUtilities.java
+++ b/src/main/java/de/digitalcollections/iiif/model/ModelUtilities.java
@@ -9,42 +9,44 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.reflections.ReflectionUtils;
 
-/**
- * Some static utility methods used for (de-)serialization and sanity checks.
- */
+/** Some static utility methods used for (de-)serialization and sanity checks. */
 public class ModelUtilities {
 
   public enum Completeness {
-    EMPTY, ID_ONLY, ID_AND_TYPE, ID_AND_TYPE_AND_LABEL, COMPLEX
+    EMPTY,
+    ID_ONLY,
+    ID_AND_TYPE,
+    ID_AND_TYPE_AND_LABEL,
+    COMPLEX
   }
 
   private static boolean containsOnly(Set<String> vals, String... toCheck) {
-    return (vals.size() == toCheck.length
-            && Arrays.stream(toCheck).allMatch(vals::contains));
+    return (vals.size() == toCheck.length && Arrays.stream(toCheck).allMatch(vals::contains));
   }
 
   /**
-   * Obtain the "completeness" (i.e. "empty", "id and type", "it, type and label", "id only" or "complex") of
-   * a IIIF resource. Can be useful for determining how to serialize the resource, e.g. often resources with only
-   * an id are serialized as a string.
+   * Obtain the "completeness" (i.e. "empty", "id and type", "it, type and label", "id only" or
+   * "complex") of a IIIF resource. Can be useful for determining how to serialize the resource,
+   * e.g. often resources with only an id are serialized as a string.
    *
    * @param res The IIIF resource to check the completeness of
    * @param type The type of the IIIF resource
    * @return the completeness
    */
   public static Completeness getCompleteness(Object res, Class<?> type) {
-    Set<Method> getters = ReflectionUtils.getAllMethods(
-        type,
-        ReflectionUtils.withModifier(Modifier.PUBLIC),
-        ReflectionUtils.withPrefix("get"));
-    Set<String> gettersWithValues = getters.stream()
-        .filter(g -> g.getAnnotation(JsonIgnore.class) == null) // Only JSON-serializable fields
-        .filter(g -> returnsValue(g, res))
-        .map(Method::getName)
-        .collect(Collectors.toSet());
+    Set<Method> getters =
+        ReflectionUtils.getAllMethods(
+            type, ReflectionUtils.withModifier(Modifier.PUBLIC), ReflectionUtils.withPrefix("get"));
+    Set<String> gettersWithValues =
+        getters.stream()
+            .filter(g -> g.getAnnotation(JsonIgnore.class) == null) // Only JSON-serializable fields
+            .filter(g -> returnsValue(g, res))
+            .map(Method::getName)
+            .collect(Collectors.toSet());
 
-    boolean hasOnlyTypeAndId = (gettersWithValues.size() == 2
-                                && Stream.of("getType", "getIdentifier").allMatch(gettersWithValues::contains));
+    boolean hasOnlyTypeAndId =
+        (gettersWithValues.size() == 2
+            && Stream.of("getType", "getIdentifier").allMatch(gettersWithValues::contains));
     if (gettersWithValues.isEmpty()) {
       return Completeness.EMPTY;
     } else if (containsOnly(gettersWithValues, "getType", "getIdentifier")) {

--- a/src/main/java/de/digitalcollections/iiif/model/Motivation.java
+++ b/src/main/java/de/digitalcollections/iiif/model/Motivation.java
@@ -6,7 +6,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 /**
  * A motivation for an annotation.
  *
- * Try to use the defined constants and only fall back to the constructor if your motivation is not covered by these.
+ * <p>Try to use the defined constants and only fall back to the constructor if your motivation is
+ * not covered by these.
  */
 public class Motivation {
 

--- a/src/main/java/de/digitalcollections/iiif/model/OtherContent.java
+++ b/src/main/java/de/digitalcollections/iiif/model/OtherContent.java
@@ -10,7 +10,7 @@ import java.net.URI;
 /**
  * Type for Content resources such as images or texts that are associated with a canvas.
  *
- * Used in the "related", "renderings" and "otherContent" fields of IIIF resources.
+ * <p>Used in the "related", "renderings" and "otherContent" fields of IIIF resources.
  */
 @JsonPropertyOrder({"@id", "@type"})
 public class OtherContent extends Resource<OtherContent> {

--- a/src/main/java/de/digitalcollections/iiif/model/Profile.java
+++ b/src/main/java/de/digitalcollections/iiif/model/Profile.java
@@ -7,8 +7,8 @@ import java.net.URI;
 /**
  * A profile for a {@link OtherContent} or {@link Service}.
  *
- * For image services, please use the more specific {@link ImageApiProfile} that has useful pre-defined constants
- * for the available Image API profiles.
+ * <p>For image services, please use the more specific {@link ImageApiProfile} that has useful
+ * pre-defined constants for the available Image API profiles.
  */
 public class Profile {
 

--- a/src/main/java/de/digitalcollections/iiif/model/PropertyValue.java
+++ b/src/main/java/de/digitalcollections/iiif/model/PropertyValue.java
@@ -1,5 +1,8 @@
 package de.digitalcollections.iiif.model;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.Lists;
@@ -16,14 +19,11 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * Type for strings that are intended to be displayed to the user.
  *
- * Is organized as a mapping of languages to one or more values.
- * See http://iiif.io/api/presentation/2.1/#language-of-property-values and
+ * <p>Is organized as a mapping of languages to one or more values. See
+ * http://iiif.io/api/presentation/2.1/#language-of-property-values and
  * http://iiif.io/api/presentation/2.1/#html-markup-in-property-values for more information.
  */
 @JsonSerialize(using = PropertyValueSerializer.class)
@@ -32,8 +32,7 @@ public class PropertyValue {
 
   private Map<Locale, List<String>> localizations = new LinkedHashMap<>();
 
-  public PropertyValue() {
-  }
+  public PropertyValue() {}
 
   public PropertyValue(String first, String... rest) {
     this(Locale.ROOT, first, rest);

--- a/src/main/java/de/digitalcollections/iiif/model/Service.java
+++ b/src/main/java/de/digitalcollections/iiif/model/Service.java
@@ -10,9 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-/**
- * Abstract base type for services.
- */
+/** Abstract base type for services. */
 @JsonPropertyOrder({"@context", "@id", "@type"})
 public abstract class Service {
 
@@ -70,8 +68,9 @@ public abstract class Service {
   }
 
   public Service addProfile(String first, String... rest) {
-    return this.addProfile(new Profile(URI.create(first)),
-                           Arrays.stream(rest).map(p -> new Profile(URI.create(p))).toArray(Profile[]::new));
+    return this.addProfile(
+        new Profile(URI.create(first)),
+        Arrays.stream(rest).map(p -> new Profile(URI.create(p))).toArray(Profile[]::new));
   }
 
   public PropertyValue getLabel() {
@@ -90,5 +89,4 @@ public abstract class Service {
   public void setLabel(String label) {
     setLabel(new PropertyValue(label));
   }
-
 }

--- a/src/main/java/de/digitalcollections/iiif/model/annex/GeoService.java
+++ b/src/main/java/de/digitalcollections/iiif/model/annex/GeoService.java
@@ -7,15 +7,14 @@ import java.net.URI;
 /**
  * A GeoJSON service (http://iiif.io/api/annex/services/#geojson).
  *
- * Initialize it either with an URL to a GeoJSON resource that identifies the linked location, or pass a
- * {@link org.geojson.Feature} object that defines the location.
+ * <p>Initialize it either with an URL to a GeoJSON resource that identifies the linked location, or
+ * pass a {@link org.geojson.Feature} object that defines the location.
  */
 public class GeoService extends Service {
 
   public static final String CONTEXT = "http://geojson.org/geojson-ld/geojson-context.jsonld";
 
-  @JsonUnwrapped
-  private org.geojson.Feature feature;
+  @JsonUnwrapped private org.geojson.Feature feature;
 
   public GeoService() {
     super(URI.create(CONTEXT));

--- a/src/main/java/de/digitalcollections/iiif/model/annex/PhysicalDimensionsService.java
+++ b/src/main/java/de/digitalcollections/iiif/model/annex/PhysicalDimensionsService.java
@@ -7,13 +7,15 @@ import de.digitalcollections.iiif.model.Service;
 import java.net.URI;
 
 /**
- * A service that describes  the physical dimensions of the resource it is associated to
+ * A service that describes the physical dimensions of the resource it is associated to
  * (http://iiif.io/api/annex/services/#physical-dimensions).
  */
 public class PhysicalDimensionsService extends Service {
 
   public enum Unit {
-    MILLIMETERS("mm"), CENTIMETERS("cm"), INCHES("in");
+    MILLIMETERS("mm"),
+    CENTIMETERS("cm"),
+    INCHES("in");
 
     private final String unit;
 
@@ -36,8 +38,9 @@ public class PhysicalDimensionsService extends Service {
   private final Unit physicalUnits;
 
   @JsonCreator
-  public PhysicalDimensionsService(@JsonProperty("physicalScale") double physicalScale,
-                                   @JsonProperty("physicalUnits") Unit units) {
+  public PhysicalDimensionsService(
+      @JsonProperty("physicalScale") double physicalScale,
+      @JsonProperty("physicalUnits") Unit units) {
     super(URI.create(CONTEXT));
     this.addProfile(PROFILE);
     this.physicalScale = physicalScale;

--- a/src/main/java/de/digitalcollections/iiif/model/auth/AccessCookieService.java
+++ b/src/main/java/de/digitalcollections/iiif/model/auth/AccessCookieService.java
@@ -12,17 +12,28 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The client uses this service to obtain a cookie that will be used when interacting with content such as images,
- * and with the access token service.
+ * The client uses this service to obtain a cookie that will be used when interacting with content
+ * such as images, and with the access token service.
  *
- * There are several different interaction patterns in which the client will use this service, based on the user
- * interface that must be rendered for the user, indicated by a profile URI. The client obtains the link to the access
- * cookie service from a service block in a description of the protected resource.
+ * <p>There are several different interaction patterns in which the client will use this service,
+ * based on the user interface that must be rendered for the user, indicated by a profile URI. The
+ * client obtains the link to the access cookie service from a service block in a description of the
+ * protected resource.
  *
- * See http://iiif.io/api/auth/1.0/#access-cookie-service
+ * <p>See http://iiif.io/api/auth/1.0/#access-cookie-service
  */
-@JsonPropertyOrder({"@context", "@id", "profile", "label", "header", "description", "confirmLabel",
-                    "failureHeader", "failureDescription", "service"})
+@JsonPropertyOrder({
+  "@context",
+  "@id",
+  "profile",
+  "label",
+  "header",
+  "description",
+  "confirmLabel",
+  "failureHeader",
+  "failureDescription",
+  "service"
+})
 public class AccessCookieService extends Service {
 
   public static final String CONTEXT = "http://iiif.io/api/auth/1/context.json";
@@ -44,7 +55,8 @@ public class AccessCookieService extends Service {
   private List<AuthService> services;
 
   @JsonCreator
-  public AccessCookieService(@JsonProperty("@id") String identifier, @JsonProperty("profile") AuthPattern pattern) {
+  public AccessCookieService(
+      @JsonProperty("@id") String identifier, @JsonProperty("profile") AuthPattern pattern) {
     this(identifier == null ? null : URI.create(identifier), pattern);
   }
 
@@ -53,7 +65,8 @@ public class AccessCookieService extends Service {
    *
    * @param identifier (optional) identifier
    * @param pattern authentication pattern
-   * @throws IllegalArgumentException If the auth pattern is not "external" and no identifier is provided.
+   * @throws IllegalArgumentException If the auth pattern is not "external" and no identifier is
+   *     provided.
    */
   public AccessCookieService(URI identifier, AuthPattern pattern) throws IllegalArgumentException {
     super(URI.create(CONTEXT));

--- a/src/main/java/de/digitalcollections/iiif/model/auth/AccessToken.java
+++ b/src/main/java/de/digitalcollections/iiif/model/auth/AccessToken.java
@@ -8,7 +8,7 @@ import java.time.Duration;
 /**
  * The access token returned by a {@link AccessTokenService}.
  *
- * See http://iiif.io/api/auth/1.0/#the-json-access-token-response
+ * <p>See http://iiif.io/api/auth/1.0/#the-json-access-token-response
  */
 public class AccessToken {
 
@@ -18,7 +18,8 @@ public class AccessToken {
   private Duration expiresIn;
 
   @JsonCreator
-  public AccessToken(@JsonProperty("accessToken") String token, @JsonProperty("expiresIn") Duration expiresIn) {
+  public AccessToken(
+      @JsonProperty("accessToken") String token, @JsonProperty("expiresIn") Duration expiresIn) {
     this.token = token;
     this.expiresIn = expiresIn;
   }

--- a/src/main/java/de/digitalcollections/iiif/model/auth/AccessTokenService.java
+++ b/src/main/java/de/digitalcollections/iiif/model/auth/AccessTokenService.java
@@ -6,12 +6,14 @@ import de.digitalcollections.iiif.model.Service;
 import java.net.URI;
 
 /**
- * The client uses this service to obtain an access token which it then uses when requesting Description Resources.
+ * The client uses this service to obtain an access token which it then uses when requesting
+ * Description Resources.
  *
- * A request to the access token service must include any cookies for the content domain acquired from the user’s
- * interaction with the corresponding access cookie service, so that the server can issue the access token.
+ * <p>A request to the access token service must include any cookies for the content domain acquired
+ * from the user’s interaction with the corresponding access cookie service, so that the server can
+ * issue the access token.
  *
- * See http://iiif.io/api/auth/1.0/#access-token-service
+ * <p>See http://iiif.io/api/auth/1.0/#access-token-service
  */
 public class AccessTokenService extends Service implements AuthService {
 

--- a/src/main/java/de/digitalcollections/iiif/model/auth/AuthPattern.java
+++ b/src/main/java/de/digitalcollections/iiif/model/auth/AuthPattern.java
@@ -5,35 +5,38 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.net.URI;
 
 /**
- * There are four interaction patterns by which the client can obtain an access cookie, each identified by a profile URI.
+ * There are four interaction patterns by which the client can obtain an access cookie, each
+ * identified by a profile URI.
  *
- * See http://iiif.io/api/auth/1.0/#service-description
+ * <p>See http://iiif.io/api/auth/1.0/#service-description
  */
 public enum AuthPattern {
   /**
-   * The user will be required to log in using a separate window with a UI provided by an external authentication system.
+   * The user will be required to log in using a separate window with a UI provided by an external
+   * authentication system.
    *
-   * See http://iiif.io/api/auth/1.0/#login-interaction-pattern
+   * <p>See http://iiif.io/api/auth/1.0/#login-interaction-pattern
    */
   LOGIN("http://iiif.io/api/auth/1/login"),
   /**
-   * The user will be required to click a button within the client using content provided in the service description.
+   * The user will be required to click a button within the client using content provided in the
+   * service description.
    *
-   * See http://iiif.io/api/auth/1.0/#clickthrough-interaction-pattern
+   * <p>See http://iiif.io/api/auth/1.0/#clickthrough-interaction-pattern
    */
   CLICKTHROUGH("http://iiif.io/api/auth/1/clickthrough"),
   /**
-   * The user will not be required to interact with an authentication system, the client is expected to use the access
-   * cookie service automatically.
+   * The user will not be required to interact with an authentication system, the client is expected
+   * to use the access cookie service automatically.
    *
-   * See http://iiif.io/api/auth/1.0/#kiosk-interaction-pattern
+   * <p>See http://iiif.io/api/auth/1.0/#kiosk-interaction-pattern
    */
   KIOSK("http://iiif.io/api/auth/1/kiosk"),
   /**
-   * The user is expected to have already acquired the appropriate cookie, and the access cookie service will not be
-   * used at all.
+   * The user is expected to have already acquired the appropriate cookie, and the access cookie
+   * service will not be used at all.
    *
-   * See http://iiif.io/api/auth/1.0/#external-interaction-pattern
+   * <p>See http://iiif.io/api/auth/1.0/#external-interaction-pattern
    */
   EXTERNAL("http://iiif.io/api/auth/1/external");
 

--- a/src/main/java/de/digitalcollections/iiif/model/auth/AuthService.java
+++ b/src/main/java/de/digitalcollections/iiif/model/auth/AuthService.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 @JsonTypeInfo(use = Id.NAME, include = As.EXISTING_PROPERTY, property = "profile")
 @JsonSubTypes({
-    @Type(name = AccessTokenService.PROFILE, value = AccessTokenService.class),
-    @Type(name = LogoutService.PROFILE, value = LogoutService.class)})
-public interface AuthService {
-}
+  @Type(name = AccessTokenService.PROFILE, value = AccessTokenService.class),
+  @Type(name = LogoutService.PROFILE, value = LogoutService.class)
+})
+public interface AuthService {}

--- a/src/main/java/de/digitalcollections/iiif/model/auth/LogoutService.java
+++ b/src/main/java/de/digitalcollections/iiif/model/auth/LogoutService.java
@@ -7,11 +7,13 @@ import de.digitalcollections.iiif.model.Service;
 import java.net.URI;
 
 /**
- * In the case of the Login interaction pattern, the client will need to know if and where the user can go to log out.
+ * In the case of the Login interaction pattern, the client will need to know if and where the user
+ * can go to log out.
  *
- * For example, the user may wish to close their session on a public terminal, or to log in again with a different account.
+ * <p>For example, the user may wish to close their session on a public terminal, or to log in again
+ * with a different account.
  *
- * See http://iiif.io/api/auth/1.0/#logout-service
+ * <p>See http://iiif.io/api/auth/1.0/#logout-service
  */
 @JsonTypeName(LogoutService.PROFILE)
 public class LogoutService extends Service implements AuthService {

--- a/src/main/java/de/digitalcollections/iiif/model/auth/errors/AccessTokenError.java
+++ b/src/main/java/de/digitalcollections/iiif/model/auth/errors/AccessTokenError.java
@@ -8,16 +8,14 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
-@JsonTypeInfo(
-    use = Id.NAME,
-    include = As.EXISTING_PROPERTY,
-    property = "error")
+@JsonTypeInfo(use = Id.NAME, include = As.EXISTING_PROPERTY, property = "error")
 @JsonSubTypes({
-    @Type(name = InvalidCredentials.TYPE, value = InvalidCredentials.class),
-    @Type(name = InvalidOrigin.TYPE, value = InvalidOrigin.class),
-    @Type(name = InvalidRequest.TYPE, value = InvalidRequest.class),
-    @Type(name = MissingCredentials.TYPE, value = MissingCredentials.class),
-    @Type(name = Unavailable.TYPE, value = Unavailable.class)})
+  @Type(name = InvalidCredentials.TYPE, value = InvalidCredentials.class),
+  @Type(name = InvalidOrigin.TYPE, value = InvalidOrigin.class),
+  @Type(name = InvalidRequest.TYPE, value = InvalidRequest.class),
+  @Type(name = MissingCredentials.TYPE, value = MissingCredentials.class),
+  @Type(name = Unavailable.TYPE, value = Unavailable.class)
+})
 @JsonIgnoreProperties({"suppressed", "stackTrace"})
 public abstract class AccessTokenError extends Exception {
 

--- a/src/main/java/de/digitalcollections/iiif/model/auth/errors/package-info.java
+++ b/src/main/java/de/digitalcollections/iiif/model/auth/errors/package-info.java
@@ -1,4 +1,5 @@
 /**
- * Error types from the IIIF Authentication API (http://iiif.io/api/auth/1.0/#access-token-error-conditions).
+ * Error types from the IIIF Authentication API
+ * (http://iiif.io/api/auth/1.0/#access-token-error-conditions).
  */
 package de.digitalcollections.iiif.model.auth.errors;

--- a/src/main/java/de/digitalcollections/iiif/model/auth/package-info.java
+++ b/src/main/java/de/digitalcollections/iiif/model/auth/package-info.java
@@ -1,4 +1,5 @@
 /**
- * Model classes that represent entities from the IIIF Authentication API (http://iiif.io/api/auth/1.0/).
+ * Model classes that represent entities from the IIIF Authentication API
+ * (http://iiif.io/api/auth/1.0/).
  */
 package de.digitalcollections.iiif.model.auth;

--- a/src/main/java/de/digitalcollections/iiif/model/enums/ViewingDirection.java
+++ b/src/main/java/de/digitalcollections/iiif/model/enums/ViewingDirection.java
@@ -2,9 +2,7 @@ package de.digitalcollections.iiif.model.enums;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-/**
- * The direction that a sequence of canvases should be displayed to the user.
- */
+/** The direction that a sequence of canvases should be displayed to the user. */
 public enum ViewingDirection {
   LEFT_TO_RIGHT("left-to-right"),
   RIGHT_TO_LEFT("right-to-left"),

--- a/src/main/java/de/digitalcollections/iiif/model/enums/ViewingHint.java
+++ b/src/main/java/de/digitalcollections/iiif/model/enums/ViewingHint.java
@@ -9,8 +9,8 @@ import java.net.URI;
 /**
  * A hint to the client as to the most appropriate method of displaying the resource.
  *
- * Try to use one of the pre-defined constants. If a custom viewing hint is desired, pass its URL identifier as
- * the sole constructor argument.
+ * <p>Try to use one of the pre-defined constants. If a custom viewing hint is desired, pass its URL
+ * identifier as the sole constructor argument.
  */
 public class ViewingHint {
 
@@ -26,60 +26,67 @@ public class ViewingHint {
   }
 
   /**
-   * Valid on collection, manifest, sequence and range. When used as the viewingHint of a collection, the client should
-   * treat each of the manifests as distinct individual objects. For manifest, sequence and range, the canvases
-   * referenced are all distinct individual views, and should not be presented in a page-turning interface. Examples
-   * include a gallery of paintings, a set of views of a 3 dimensional object, or a set of the front sides of
-   * photographs in a collection.
+   * Valid on collection, manifest, sequence and range. When used as the viewingHint of a
+   * collection, the client should treat each of the manifests as distinct individual objects. For
+   * manifest, sequence and range, the canvases referenced are all distinct individual views, and
+   * should not be presented in a page-turning interface. Examples include a gallery of paintings, a
+   * set of views of a 3 dimensional object, or a set of the front sides of photographs in a
+   * collection.
    */
   public static ViewingHint INDIVIDUALS = new ViewingHint(Type.INDIVIDUALS);
 
   /**
-   * Valid on manifest, sequence and range. Canvases with this viewingHint represent pages in a bound volume, and should
-   * be presented in a page-turning interface if one is available. The first canvas is a single view (the first recto)
-   * and thus the second canvas represents the back of the object in the first canvas.
+   * Valid on manifest, sequence and range. Canvases with this viewingHint represent pages in a
+   * bound volume, and should be presented in a page-turning interface if one is available. The
+   * first canvas is a single view (the first recto) and thus the second canvas represents the back
+   * of the object in the first canvas.
    */
   public static ViewingHint PAGED = new ViewingHint(Type.PAGED);
 
   /**
-   * Valid on manifest, sequence and range. A canvas with this viewingHint is a partial view and an appropriate
-   * rendering might display either the canvases individually, or all of the canvases virtually stitched together in the
-   * display. Examples when this would be appropriate include long scrolls, rolls, or objects designed to be displayed
-   * adjacent to each other. If this viewingHint is present, then the resource must also have a viewingDirection which
-   * will determine the arrangement of the canvases. Note that this does not allow for both sides of a scroll to be
-   * included in the same manifest with this viewingHint. To accomplish that, the manifest should be “individuals” and
-   * have two ranges, one for each side, which are “continuous”.
+   * Valid on manifest, sequence and range. A canvas with this viewingHint is a partial view and an
+   * appropriate rendering might display either the canvases individually, or all of the canvases
+   * virtually stitched together in the display. Examples when this would be appropriate include
+   * long scrolls, rolls, or objects designed to be displayed adjacent to each other. If this
+   * viewingHint is present, then the resource must also have a viewingDirection which will
+   * determine the arrangement of the canvases. Note that this does not allow for both sides of a
+   * scroll to be included in the same manifest with this viewingHint. To accomplish that, the
+   * manifest should be “individuals” and have two ranges, one for each side, which are
+   * “continuous”.
    */
   public static ViewingHint CONTINUOUS = new ViewingHint(Type.CONTINUOUS);
 
   /**
-   * Valid only for collections. Collections with this viewingHint consist of multiple manifests that each form part of
-   * a logical whole. Clients might render the collection as a table of contents, rather than with thumbnails. Examples
-   * include multi-volume books or a set of journal issues or other serials.
+   * Valid only for collections. Collections with this viewingHint consist of multiple manifests
+   * that each form part of a logical whole. Clients might render the collection as a table of
+   * contents, rather than with thumbnails. Examples include multi-volume books or a set of journal
+   * issues or other serials.
    */
   public static ViewingHint MULTI_PART = new ViewingHint(Type.MULTI_PART);
 
   /**
-   * Valid only for canvases. Canvases with this viewingHint must not be presented in a page turning interface, and must
-   * be skipped over when determining the page sequence. This viewing hint must be ignored if the current sequence or
-   * manifest does not have the ‘paged’ viewing hint.
+   * Valid only for canvases. Canvases with this viewingHint must not be presented in a page turning
+   * interface, and must be skipped over when determining the page sequence. This viewing hint must
+   * be ignored if the current sequence or manifest does not have the ‘paged’ viewing hint.
    */
   public static ViewingHint NON_PAGED = new ViewingHint(Type.NON_PAGED);
 
   /**
-   * Valid only for ranges. A Range with this viewingHint is the top-most node in a hierarchy of ranges that represents
-   * a structure to be rendered by the client to assist in navigation. For example, a table of contents within a paged
-   * object, major sections of a 3d object, the textual areas within a single scroll, and so forth. Other ranges that
-   * are descendants of the “top” range are the entries to be rendered in the navigation structure. There may be
-   * multiple ranges marked with this hint. If so, the client should display a choice of multiple structures to navigate
-   * through.
+   * Valid only for ranges. A Range with this viewingHint is the top-most node in a hierarchy of
+   * ranges that represents a structure to be rendered by the client to assist in navigation. For
+   * example, a table of contents within a paged object, major sections of a 3d object, the textual
+   * areas within a single scroll, and so forth. Other ranges that are descendants of the “top”
+   * range are the entries to be rendered in the navigation structure. There may be multiple ranges
+   * marked with this hint. If so, the client should display a choice of multiple structures to
+   * navigate through.
    */
   public static ViewingHint TOP = new ViewingHint(Type.TOP);
 
   /**
-   * Valid only for canvases. Canvases with this viewingHint, in a sequence or manifest with the “paged” viewing hint,
-   * must be displayed by themselves, as they depict both parts of the opening. If all of the canvases are like this,
-   * then page turning is not possible, so simply use “individuals” instead.
+   * Valid only for canvases. Canvases with this viewingHint, in a sequence or manifest with the
+   * “paged” viewing hint, must be displayed by themselves, as they depict both parts of the
+   * opening. If all of the canvases are like this, then page turning is not possible, so simply use
+   * “individuals” instead.
    */
   public static ViewingHint FACING_PAGES = new ViewingHint(Type.FACING_PAGES);
 
@@ -135,8 +142,7 @@ public class ViewingHint {
       return false;
     }
     ViewingHint that = (ViewingHint) o;
-    return this.type == that.type
-           && (uri != null ? uri.equals(that.uri) : that.uri == null);
+    return this.type == that.type && (uri != null ? uri.equals(that.uri) : that.uri == null);
   }
 
   @Override

--- a/src/main/java/de/digitalcollections/iiif/model/image/ImageApiProfile.java
+++ b/src/main/java/de/digitalcollections/iiif/model/image/ImageApiProfile.java
@@ -19,11 +19,12 @@ import java.util.stream.Stream;
 /**
  * An Image API profile.
  *
- * Can be either a simple pre-defined profile (e.g. {@link ImageApiProfile#LEVEL_ZERO}) or a complex profile
- * describing the available features of a given IIIF image.
+ * <p>Can be either a simple pre-defined profile (e.g. {@link ImageApiProfile#LEVEL_ZERO}) or a
+ * complex profile describing the available features of a given IIIF image.
  *
- * See http://iiif.io/api/image/2.1/#profile-description for an overview of all available properties and features
- * and http://iiif.io/api/image/2.1/compliance/ for an overview of the available compliance levels.
+ * <p>See http://iiif.io/api/image/2.1/#profile-description for an overview of all available
+ * properties and features and http://iiif.io/api/image/2.1/compliance/ for an overview of the
+ * available compliance levels.
  */
 public class ImageApiProfile extends Profile {
 
@@ -54,7 +55,10 @@ public class ImageApiProfile extends Profile {
   }
 
   public enum Quality {
-    COLOR, GRAY, BITONAL, DEFAULT;
+    COLOR,
+    GRAY,
+    BITONAL,
+    DEFAULT;
 
     @JsonValue
     @Override
@@ -66,64 +70,98 @@ public class ImageApiProfile extends Profile {
   public static class Feature {
 
     private enum ImageApiFeature {
-      BASE_URI_REDIRECT, CANONICAL_LINK_HEADER, CORS, JSONLD_MEDIA_TYPE, MIRRORING, PROFILE_LINK_HEADER,
-      REGION_BY_PCT, REGION_BY_PX, REGION_SQUARE, ROTATION_ARBITRARY, ROTATION_BY_90S, SIZE_ABOVE_FULL,
-      SIZE_BY_WH_LISTED, SIZE_BY_FORCED_WH, SIZE_BY_H, SIZE_BY_PCT, SIZE_BY_W, SIZE_BY_WH, SIZE_BY_CONFINED_WH,
-      SIZE_BY_DISTORTED_WH, OTHER
+      BASE_URI_REDIRECT,
+      CANONICAL_LINK_HEADER,
+      CORS,
+      JSONLD_MEDIA_TYPE,
+      MIRRORING,
+      PROFILE_LINK_HEADER,
+      REGION_BY_PCT,
+      REGION_BY_PX,
+      REGION_SQUARE,
+      ROTATION_ARBITRARY,
+      ROTATION_BY_90S,
+      SIZE_ABOVE_FULL,
+      SIZE_BY_WH_LISTED,
+      SIZE_BY_FORCED_WH,
+      SIZE_BY_H,
+      SIZE_BY_PCT,
+      SIZE_BY_W,
+      SIZE_BY_WH,
+      SIZE_BY_CONFINED_WH,
+      SIZE_BY_DISTORTED_WH,
+      OTHER
     }
 
-    /** The base URI of the service will redirect to the image information document. **/
+    /** The base URI of the service will redirect to the image information document. * */
     public static final Feature BASE_URI_REDIRECT = new Feature(ImageApiFeature.BASE_URI_REDIRECT);
 
-    /** The canonical image URI HTTP link header is provided on image responses. **/
-    public static final Feature CANONICAL_LINK_HEADER = new Feature(ImageApiFeature.CANONICAL_LINK_HEADER);
+    /** The canonical image URI HTTP link header is provided on image responses. * */
+    public static final Feature CANONICAL_LINK_HEADER =
+        new Feature(ImageApiFeature.CANONICAL_LINK_HEADER);
 
-    /** The CORS HTTP header is provided on all responses. **/
+    /** The CORS HTTP header is provided on all responses. * */
     public static final Feature CORS = new Feature(ImageApiFeature.CORS);
 
-    /** The JSON-LD media type is provided when JSON-LD is requested. **/
+    /** The JSON-LD media type is provided when JSON-LD is requested. * */
     public static final Feature JSONLD_MEDIA_TYPE = new Feature(ImageApiFeature.JSONLD_MEDIA_TYPE);
 
-    /** The image may be rotated around the vertical axis, resulting in a left-to-right mirroring of the content. **/
+    /**
+     * The image may be rotated around the vertical axis, resulting in a left-to-right mirroring of
+     * the content. *
+     */
     public static final Feature MIRRORING = new Feature(ImageApiFeature.MIRRORING);
 
-    /** The profile HTTP link header is provided on image responses. **/
-    public static final Feature PROFILE_LINK_HEADER = new Feature(ImageApiFeature.PROFILE_LINK_HEADER);
+    /** The profile HTTP link header is provided on image responses. * */
+    public static final Feature PROFILE_LINK_HEADER =
+        new Feature(ImageApiFeature.PROFILE_LINK_HEADER);
 
-    /** Regions of images may be requested by percentage. **/
+    /** Regions of images may be requested by percentage. * */
     public static final Feature REGION_BY_PCT = new Feature(ImageApiFeature.REGION_BY_PCT);
 
-    /** Regions of images may be requested by pixel dimensions. **/
+    /** Regions of images may be requested by pixel dimensions. * */
     public static final Feature REGION_BY_PX = new Feature(ImageApiFeature.REGION_BY_PX);
 
-    /** A square region where the width and height are equal to the shorter dimension of the complete image content. **/
+    /**
+     * A square region where the width and height are equal to the shorter dimension of the complete
+     * image content. *
+     */
     public static final Feature REGION_SQUARE = new Feature(ImageApiFeature.REGION_SQUARE);
 
-    /** Rotation of images may be requested by degrees other than multiples of 90. **/
-    public static final Feature ROTATION_ARBITRARY = new Feature(ImageApiFeature.ROTATION_ARBITRARY);
+    /** Rotation of images may be requested by degrees other than multiples of 90. * */
+    public static final Feature ROTATION_ARBITRARY =
+        new Feature(ImageApiFeature.ROTATION_ARBITRARY);
 
-    /** Rotation of images may be requested by degrees in multiples of 90. **/
+    /** Rotation of images may be requested by degrees in multiples of 90. * */
     public static final Feature ROTATION_BY_90S = new Feature(ImageApiFeature.ROTATION_BY_90S);
 
-    /** Size of images may be requested larger than the “full” size. See warning. **/
+    /** Size of images may be requested larger than the “full” size. See warning. * */
     public static final Feature SIZE_ABOVE_FULL = new Feature(ImageApiFeature.SIZE_ABOVE_FULL);
 
-    /** Size of images may be requested in the form “!w,h”. **/
-    public static final Feature SIZE_BY_CONFINED_WH = new Feature(ImageApiFeature.SIZE_BY_CONFINED_WH);
+    /** Size of images may be requested in the form “!w,h”. * */
+    public static final Feature SIZE_BY_CONFINED_WH =
+        new Feature(ImageApiFeature.SIZE_BY_CONFINED_WH);
 
-    /** Size of images may be requested in the form “w,h”, including sizes that would distort the image. **/
-    public static final Feature SIZE_BY_DISTORTED_WH = new Feature(ImageApiFeature.SIZE_BY_DISTORTED_WH);
+    /**
+     * Size of images may be requested in the form “w,h”, including sizes that would distort the
+     * image. *
+     */
+    public static final Feature SIZE_BY_DISTORTED_WH =
+        new Feature(ImageApiFeature.SIZE_BY_DISTORTED_WH);
 
-    /** Size of images may be requested in the form “,h”. **/
+    /** Size of images may be requested in the form “,h”. * */
     public static final Feature SIZE_BY_H = new Feature(ImageApiFeature.SIZE_BY_H);
 
-    /** Size of images may be requested in the form “pct:n”.**/
+    /** Size of images may be requested in the form “pct:n”.* */
     public static final Feature SIZE_BY_PCT = new Feature(ImageApiFeature.SIZE_BY_PCT);
 
-    /** Size of images may be requested in the form “w,”. **/
+    /** Size of images may be requested in the form “w,”. * */
     public static final Feature SIZE_BY_W = new Feature(ImageApiFeature.SIZE_BY_W);
 
-    /** Size of images may be requested in the form “w,h” where the supplied w and h preserve the aspect ratio. **/
+    /**
+     * Size of images may be requested in the form “w,h” where the supplied w and h preserve the
+     * aspect ratio. *
+     */
     public static final Feature SIZE_BY_WH = new Feature(ImageApiFeature.SIZE_BY_WH);
 
     @Deprecated
@@ -170,18 +208,20 @@ public class ImageApiProfile extends Profile {
       }
       Feature other = (Feature) obj;
       return Objects.equals(this.imageApiFeature, other.imageApiFeature)
-             && Objects.equals(this.customFeature, other.customFeature);
+          && Objects.equals(this.customFeature, other.customFeature);
     }
   }
 
-  public static final ImageApiProfile LEVEL_ZERO = new ImageApiProfile("http://iiif.io/api/image/2/level0.json");
+  public static final ImageApiProfile LEVEL_ZERO =
+      new ImageApiProfile("http://iiif.io/api/image/2/level0.json");
 
   static {
     LEVEL_ZERO.addFormat(Format.JPG);
     LEVEL_ZERO.addQuality(Quality.DEFAULT);
   }
 
-  public static final ImageApiProfile LEVEL_ONE = new ImageApiProfile("http://iiif.io/api/image/2/level1.json");
+  public static final ImageApiProfile LEVEL_ONE =
+      new ImageApiProfile("http://iiif.io/api/image/2/level1.json");
 
   static {
     LEVEL_ONE.addFeature(
@@ -196,7 +236,8 @@ public class ImageApiProfile extends Profile {
     LEVEL_ONE.addQuality(Quality.DEFAULT);
   }
 
-  public static final ImageApiProfile LEVEL_TWO = new ImageApiProfile("http://iiif.io/api/image/2/level2.json");
+  public static final ImageApiProfile LEVEL_TWO =
+      new ImageApiProfile("http://iiif.io/api/image/2/level2.json");
 
   static {
     LEVEL_TWO.addFeature(
@@ -216,19 +257,21 @@ public class ImageApiProfile extends Profile {
     LEVEL_TWO.addQuality(Quality.DEFAULT, Quality.COLOR, Quality.GRAY, Quality.BITONAL);
   }
 
-  public static final Set<String> V1_PROFILES = ImmutableSet.of(
-      "http://library.stanford.edu/iiif/image-api/compliance.html#level0",
-      "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level0",
-      "http://library.stanford.edu/iiif/image-api/1.1/conformance.html#level0",
-      "http://library.stanford.edu/iiif/image-api/compliance.html#level1",
-      "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level1",
-      "http://library.stanford.edu/iiif/image-api/1.1/conformance.html#level1",
-      "http://library.stanford.edu/iiif/image-api/compliance.html#level2",
-      "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
-      "http://library.stanford.edu/iiif/image-api/1.1/conformance.html#level2");
+  public static final Set<String> V1_PROFILES =
+      ImmutableSet.of(
+          "http://library.stanford.edu/iiif/image-api/compliance.html#level0",
+          "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level0",
+          "http://library.stanford.edu/iiif/image-api/1.1/conformance.html#level0",
+          "http://library.stanford.edu/iiif/image-api/compliance.html#level1",
+          "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level1",
+          "http://library.stanford.edu/iiif/image-api/1.1/conformance.html#level1",
+          "http://library.stanford.edu/iiif/image-api/compliance.html#level2",
+          "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+          "http://library.stanford.edu/iiif/image-api/1.1/conformance.html#level2");
 
   @JsonProperty("@context")
   public static final String CONTEXT = "http://iiif.io/api/image/2/context.json";
+
   @JsonProperty("@type")
   public static final String TYPE = "iiif:ImageProfile";
 
@@ -357,7 +400,8 @@ public class ImageApiProfile extends Profile {
   }
 
   /**
-   * Merge multiple profiles into one. Useful for image servers that want to consolidate the limits given in a info.json.
+   * Merge multiple profiles into one. Useful for image servers that want to consolidate the limits
+   * given in a info.json.
    *
    * @param profiles profiles to be merged
    * @return merged profile

--- a/src/main/java/de/digitalcollections/iiif/model/image/ImageApiSelector.java
+++ b/src/main/java/de/digitalcollections/iiif/model/image/ImageApiSelector.java
@@ -19,7 +19,7 @@ import org.dmfs.rfc3986.encoding.Precoded;
 /**
  * A selector that describes a region on an IIIF Image API resource.
  *
- * See http://iiif.io/api/annex/openannotation/#iiif-image-api-selector
+ * <p>See http://iiif.io/api/annex/openannotation/#iiif-image-api-selector
  */
 @JsonTypeName(ImageApiSelector.TYPE)
 public class ImageApiSelector implements Selector {
@@ -27,12 +27,13 @@ public class ImageApiSelector implements Selector {
   public static String CONTEXT = "http://iiif.io/api/annex/openannotation/context.json";
   public static final String TYPE = "iiif:ImageApiSelector";
 
-  private static final Pattern REQUEST_PAT = Pattern.compile(
-      "/?(?<identifier>[^/]+)"
-      + "/(?<region>[^/]+)"
-      + "/(?<size>[^/]+)"
-      + "/(?<rotation>[^/]+)"
-      + "/(?<quality>[^/]+?)\\.(?<format>[^/]+?)$");
+  private static final Pattern REQUEST_PAT =
+      Pattern.compile(
+          "/?(?<identifier>[^/]+)"
+              + "/(?<region>[^/]+)"
+              + "/(?<size>[^/]+)"
+              + "/(?<rotation>[^/]+)"
+              + "/(?<quality>[^/]+?)\\.(?<format>[^/]+?)$");
 
   private String identifier;
   private RegionRequest region;
@@ -98,13 +99,15 @@ public class ImageApiSelector implements Selector {
         Objects.toString(format, "jpg"));
   }
 
-  /** The spec says we have to urlencode values, but only characters outside of the US ASCII range and gen-delims
-   * from RFC3986. However, our URL library can only encode the full set of gen-delims (EXCEPT the colon) and sub-delims,
-   * which iswhy we have to manually decode the encoded sub-delims...
-   * Great and pragmatic choice for readability, more code for us :-) */
+  /**
+   * The spec says we have to urlencode values, but only characters outside of the US ASCII range
+   * and gen-delims from RFC3986. However, our URL library can only encode the full set of
+   * gen-delims (EXCEPT the colon) and sub-delims, which iswhy we have to manually decode the
+   * encoded sub-delims... Great and pragmatic choice for readability, more code for us :-)
+   */
   private static String urlEncode(String str) {
-    Set<String> excluded = ImmutableSet.of(
-        ":", "!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "=");
+    Set<String> excluded =
+        ImmutableSet.of(":", "!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "=");
     String encoded = new Encoded(str).toString();
     for (String ex : excluded) {
       encoded = encoded.replaceAll(new Encoded(ex).toString(), ex);
@@ -113,19 +116,25 @@ public class ImageApiSelector implements Selector {
   }
 
   /**
-   *  Create the canonical of the Image API request.See http://iiif.io/api/image/2.1/#canonical-uri-syntax
+   * Create the canonical of the Image API request.See
+   * http://iiif.io/api/image/2.1/#canonical-uri-syntax
    *
-   * @param nativeSize      Native size of the image the selector is applied to
-   * @param profile         Image API profile used
-   * @param defaultQuality  The native/default quality of the image the selector is applied to
+   * @param nativeSize Native size of the image the selector is applied to
+   * @param profile Image API profile used
+   * @param defaultQuality The native/default quality of the image the selector is applied to
    * @return The canonical form of the Image API request
-   * @throws de.digitalcollections.iiif.model.image.ResolvingException if RegionRequest can not be instantiated from canonical form of region
+   * @throws de.digitalcollections.iiif.model.image.ResolvingException if RegionRequest can not be
+   *     instantiated from canonical form of region
    */
-  public String getCanonicalForm(Dimension nativeSize, ImageApiProfile profile, Quality defaultQuality) throws ResolvingException {
+  public String getCanonicalForm(
+      Dimension nativeSize, ImageApiProfile profile, Quality defaultQuality)
+      throws ResolvingException {
     Dimension scaleReference = nativeSize;
-    Rectangle2D canonicalRegion = RegionRequest.fromString(region.getCanonicalForm(nativeSize)).getRegion();
+    Rectangle2D canonicalRegion =
+        RegionRequest.fromString(region.getCanonicalForm(nativeSize)).getRegion();
     if (canonicalRegion != null) {
-      scaleReference = new Dimension((int) canonicalRegion.getWidth(), (int) canonicalRegion.getHeight());
+      scaleReference =
+          new Dimension((int) canonicalRegion.getWidth(), (int) canonicalRegion.getHeight());
     }
     return String.format(
         "%s%s/%s/%s/%s.%s",

--- a/src/main/java/de/digitalcollections/iiif/model/image/ImageService.java
+++ b/src/main/java/de/digitalcollections/iiif/model/image/ImageService.java
@@ -15,11 +15,12 @@ import java.util.List;
 /**
  * A IIIF Image API service.
  *
- * See http://iiif.io/api/presentation/2.1/#image-resources
+ * <p>See http://iiif.io/api/presentation/2.1/#image-resources
  */
 public class ImageService extends Service {
 
-  // FIXME: This should be static, but for some reason Jackson ignores it if it's not on the instance...
+  // FIXME: This should be static, but for some reason Jackson ignores it if it's not on the
+  // instance...
   @SuppressWarnings("checkstyle:membername")
   @JsonProperty("protocol")
   public final String PROTOCOL = "http://iiif.io/api/image";
@@ -31,6 +32,7 @@ public class ImageService extends Service {
   private Integer height;
   private List<TileInfo> tiles;
   private List<Size> sizes;
+
   @JsonProperty("service")
   private List<Service> services;
 

--- a/src/main/java/de/digitalcollections/iiif/model/image/RegionRequest.java
+++ b/src/main/java/de/digitalcollections/iiif/model/image/RegionRequest.java
@@ -13,7 +13,10 @@ import java.util.stream.Stream;
 
 public class RegionRequest {
 
-  /** We use BigDecimals for the relative region, since we want to preserve the precision of the request **/
+  /**
+   * We use BigDecimals for the relative region, since we want to preserve the precision of the
+   * request *
+   */
   private class RelativeBox {
 
     final BigDecimal x;
@@ -53,7 +56,8 @@ public class RegionRequest {
   private RelativeBox relativeBox;
   private boolean square = false;
 
-  private static final Pattern PARSE_PAT = Pattern.compile("^(pct:)?([0-9.]+),([0-9.]+),([0-9.]+),([0-9.]+)$");
+  private static final Pattern PARSE_PAT =
+      Pattern.compile("^(pct:)?([0-9.]+),([0-9.]+),([0-9.]+),([0-9.]+)$");
 
   /**
    * Parse an IIIF Image API compliant region request string
@@ -89,15 +93,14 @@ public class RegionRequest {
     }
   }
 
-  /**
-   * Create a region that encompasses the whole picture, i.e. the 'full' syntax.
-   */
+  /** Create a region that encompasses the whole picture, i.e. the 'full' syntax. */
   public RegionRequest() {
     this(false);
   }
 
   /**
-   * Pass 'true' to create a region that selects a square region from the image, i.e.the 'square' syntax.
+   * Pass 'true' to create a region that selects a square region from the image, i.e.the 'square'
+   * syntax.
    *
    * @param square true, if square region should be selected
    */
@@ -105,7 +108,8 @@ public class RegionRequest {
     this.square = square;
   }
 
-  private RegionRequest(BigDecimal x, BigDecimal y, BigDecimal width, BigDecimal height) throws ResolvingException {
+  private RegionRequest(BigDecimal x, BigDecimal y, BigDecimal width, BigDecimal height)
+      throws ResolvingException {
     if (Stream.of(x, y, width, height).anyMatch(v -> v.doubleValue() > 100.0)) {
       throw new ResolvingException("No parameter can be greater than 100!");
     }
@@ -113,9 +117,10 @@ public class RegionRequest {
   }
 
   /**
-   * Create a RegionRequest request that is expressed using relative values, i.e.the "pct:x,y,w,h" syntax
+   * Create a RegionRequest request that is expressed using relative values, i.e.the "pct:x,y,w,h"
+   * syntax
    *
-   * The values must be between 0.0 and 100.0.
+   * <p>The values must be between 0.0 and 100.0.
    *
    * @param x relative upper left x position of region
    * @param y relative upper left y position of region
@@ -124,7 +129,11 @@ public class RegionRequest {
    * @throws ResolvingException if the values fall outside of the allowed range
    */
   public RegionRequest(double x, double y, double width, double height) throws ResolvingException {
-    this(BigDecimal.valueOf(x), BigDecimal.valueOf(y), BigDecimal.valueOf(width), BigDecimal.valueOf(height));
+    this(
+        BigDecimal.valueOf(x),
+        BigDecimal.valueOf(y),
+        BigDecimal.valueOf(width),
+        BigDecimal.valueOf(height));
   }
 
   /**
@@ -186,18 +195,21 @@ public class RegionRequest {
     if (relativeBox == null && absoluteBox == null) {
       return "full";
     } else if (isRelative()) {
-      return String.format("pct:%s,%s,%s,%s", relativeBox.x, relativeBox.y, relativeBox.w, relativeBox.h);
+      return String.format(
+          "pct:%s,%s,%s,%s", relativeBox.x, relativeBox.y, relativeBox.w, relativeBox.h);
     } else {
-      return String.format("%d,%d,%d,%d", absoluteBox.x, absoluteBox.y, absoluteBox.width, absoluteBox.height);
+      return String.format(
+          "%d,%d,%d,%d", absoluteBox.x, absoluteBox.y, absoluteBox.width, absoluteBox.height);
     }
   }
 
   public String getCanonicalForm(Dimension imageDims) throws ResolvingException {
     Rectangle resolved = this.resolve(imageDims);
-    boolean isFull = resolved.x == 0
-        && resolved.y == 0
-        && resolved.width == imageDims.width
-        && resolved.height == imageDims.height;
+    boolean isFull =
+        resolved.x == 0
+            && resolved.y == 0
+            && resolved.width == imageDims.width
+            && resolved.height == imageDims.height;
     if (isFull) {
       return "full";
     } else {
@@ -210,20 +222,17 @@ public class RegionRequest {
    *
    * @param imageDims actual image dimensions
    * @return Rectangle representing th actual region
-   * @throws de.digitalcollections.iiif.model.image.ResolvingException if rectangle is outside image dimensions
+   * @throws de.digitalcollections.iiif.model.image.ResolvingException if rectangle is outside image
+   *     dimensions
    */
   public Rectangle resolve(Dimension imageDims) throws ResolvingException {
     if (square) {
       if (imageDims.width > imageDims.height) {
         return new Rectangle(
-            (imageDims.width - imageDims.height) / 2,
-            0,
-            imageDims.height, imageDims.height);
+            (imageDims.width - imageDims.height) / 2, 0, imageDims.height, imageDims.height);
       } else if (imageDims.height > imageDims.width) {
         return new Rectangle(
-            0,
-            (imageDims.height - imageDims.width) / 2,
-            imageDims.width, imageDims.width);
+            0, (imageDims.height - imageDims.width) / 2, imageDims.width, imageDims.width);
       }
     }
     if (absoluteBox == null && relativeBox == null) {
@@ -231,11 +240,12 @@ public class RegionRequest {
     }
     Rectangle rect;
     if (isRelative()) {
-      rect = new Rectangle(
-          (int) Math.round(relativeBox.x.doubleValue() / 100. * imageDims.getWidth()),
-          (int) Math.round(relativeBox.y.doubleValue() / 100. * imageDims.getHeight()),
-          (int) Math.round(relativeBox.w.doubleValue() / 100. * imageDims.getWidth()),
-          (int) Math.round(relativeBox.h.doubleValue() / 100. * imageDims.getHeight()));
+      rect =
+          new Rectangle(
+              (int) Math.round(relativeBox.x.doubleValue() / 100. * imageDims.getWidth()),
+              (int) Math.round(relativeBox.y.doubleValue() / 100. * imageDims.getHeight()),
+              (int) Math.round(relativeBox.w.doubleValue() / 100. * imageDims.getWidth()),
+              (int) Math.round(relativeBox.h.doubleValue() / 100. * imageDims.getHeight()));
     } else {
       rect = absoluteBox;
     }
@@ -261,8 +271,8 @@ public class RegionRequest {
     }
     RegionRequest that = (RegionRequest) o;
     return square == that.square
-       && Objects.equal(absoluteBox, that.absoluteBox)
-       && Objects.equal(relativeBox, that.relativeBox);
+        && Objects.equal(absoluteBox, that.absoluteBox)
+        && Objects.equal(relativeBox, that.relativeBox);
   }
 
   @Override

--- a/src/main/java/de/digitalcollections/iiif/model/image/RotationRequest.java
+++ b/src/main/java/de/digitalcollections/iiif/model/image/RotationRequest.java
@@ -27,9 +27,7 @@ public class RotationRequest {
     if (!matcher.matches()) {
       throw new ResolvingException("Bad format: " + str);
     }
-    return new RotationRequest(
-        new BigDecimal(matcher.group(2)),
-        !(matcher.group(1) == null));
+    return new RotationRequest(new BigDecimal(matcher.group(2)), !(matcher.group(1) == null));
   }
 
   public RotationRequest(int rotation) throws ResolvingException {
@@ -83,8 +81,7 @@ public class RotationRequest {
       return false;
     }
     RotationRequest that = (RotationRequest) o;
-    return mirror == that.mirror
-           && Objects.equal(rotation, that.rotation);
+    return mirror == that.mirror && Objects.equal(rotation, that.rotation);
   }
 
   @Override

--- a/src/main/java/de/digitalcollections/iiif/model/image/Size.java
+++ b/src/main/java/de/digitalcollections/iiif/model/image/Size.java
@@ -3,17 +3,14 @@ package de.digitalcollections.iiif.model.image;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/**
- * A (width, height) tuple that describes an image's size
- */
+/** A (width, height) tuple that describes an image's size */
 public class Size {
 
   private final int width;
   private final int height;
 
   @JsonCreator
-  public Size(@JsonProperty("width") int width,
-              @JsonProperty("height") int height) {
+  public Size(@JsonProperty("width") int width, @JsonProperty("height") int height) {
     this.width = width;
     this.height = height;
   }

--- a/src/main/java/de/digitalcollections/iiif/model/image/SizeRequest.java
+++ b/src/main/java/de/digitalcollections/iiif/model/image/SizeRequest.java
@@ -14,7 +14,8 @@ import java.util.regex.Pattern;
 
 public class SizeRequest {
 
-  private static final Pattern PARSE_PAT = Pattern.compile("^(!|pct:)?(?:([0-9]+)?,([0-9]+)?|([0-9.]+))$");
+  private static final Pattern PARSE_PAT =
+      Pattern.compile("^(!|pct:)?(?:([0-9]+)?,([0-9]+)?|([0-9.]+))$");
   private boolean max = false;
   private boolean bestFit = false;
   private Integer width = null;
@@ -43,9 +44,7 @@ public class SizeRequest {
     if (matcher.group(1) != null) {
       if (matcher.group(1).equals("!")) {
         return new SizeRequest(
-            Integer.valueOf(matcher.group(2)),
-            Integer.valueOf(matcher.group(3)),
-            true);
+            Integer.valueOf(matcher.group(2)), Integer.valueOf(matcher.group(3)), true);
       } else if (matcher.group(1).equals("pct:")) {
         return new SizeRequest(new BigDecimal(matcher.group(4)));
       }
@@ -61,16 +60,14 @@ public class SizeRequest {
     return new SizeRequest(width, height);
   }
 
-  /**
-   * Create a size request for the full native resolution of the image region.
-   */
+  /** Create a size request for the full native resolution of the image region. */
   public SizeRequest() {
     this(false);
   }
 
   /**
-   * Create a size request for the maximum supported size of the image region, if isMax is true.
-   * If isMax is false, it behaves identically to the default constructor.
+   * Create a size request for the maximum supported size of the image region, if isMax is true. If
+   * isMax is false, it behaves identically to the default constructor.
    *
    * @param isMax true causes a size request for the maximum supported size of the image region
    */
@@ -79,8 +76,8 @@ public class SizeRequest {
   }
 
   /**
-   * Create a size request for a given width or height.
-   * One of both can be null (the other value will be determined based on the aspect ratio of the image region), but not both at once.
+   * Create a size request for a given width or height. One of both can be null (the other value
+   * will be determined based on the aspect ratio of the image region), but not both at once.
    *
    * @param width width of size request
    * @param height height of size request
@@ -95,12 +92,14 @@ public class SizeRequest {
   }
 
   /**
-   * Create a size request for a given width and height and signal that the server can decide to render smaller
-   * resolutions as it deems neccessary.
+   * Create a size request for a given width and height and signal that the server can decide to
+   * render smaller resolutions as it deems neccessary.
+   *
    * @param width width of size request
    * @param height height of size request
    * @param bestFit true, if server can decide to render smaller resolutions as it deems neccessary
-   * @throws de.digitalcollections.iiif.model.image.ResolvingException if params can not be resolved to Size Request
+   * @throws de.digitalcollections.iiif.model.image.ResolvingException if params can not be resolved
+   *     to Size Request
    */
   public SizeRequest(int width, int height, boolean bestFit) throws ResolvingException {
     this(width, height);
@@ -108,7 +107,8 @@ public class SizeRequest {
   }
 
   /**
-   * Create a size request that scaled both dimensions according to a fixed percentage, maintaining the aspect ratio.
+   * Create a size request that scaled both dimensions according to a fixed percentage, maintaining
+   * the aspect ratio.
    *
    * @param percentage scaling percentage, maintaining aspect ratio
    * @throws ResolvingException if the percentage is not between 0 and 100
@@ -167,14 +167,17 @@ public class SizeRequest {
 
   /**
    * Get the canonical form of this request.
-   * @see <a href="http://iiif.io/api/image/2.1/#canonical-uri-syntax">IIIF Image API specification</a>
    *
+   * @see <a href="http://iiif.io/api/image/2.1/#canonical-uri-syntax">IIIF Image API
+   *     specification</a>
    * @param nativeSize native size of request
    * @param profile image api profile
    * @return canonical form of this request
-   * @throws de.digitalcollections.iiif.model.image.ResolvingException if nativeSize can not be converted to canonical form
+   * @throws de.digitalcollections.iiif.model.image.ResolvingException if nativeSize can not be
+   *     converted to canonical form
    */
-  public String getCanonicalForm(Dimension nativeSize, ImageApiProfile profile) throws ResolvingException {
+  public String getCanonicalForm(Dimension nativeSize, ImageApiProfile profile)
+      throws ResolvingException {
     Dimension resolved = this.resolve(nativeSize, profile);
     // "w," requests are already canonical
     double nativeRatio = nativeSize.getWidth() / nativeSize.getHeight();
@@ -184,38 +187,45 @@ public class SizeRequest {
     } else if (this.width != null && this.height == null) {
       return this.toString();
     } else if (Math.floor(resolvedRatio * nativeSize.getHeight()) == nativeSize.getWidth()
-               || Math.ceil(resolvedRatio * nativeSize.getHeight()) == nativeSize.getWidth()) {
+        || Math.ceil(resolvedRatio * nativeSize.getHeight()) == nativeSize.getWidth()) {
       return String.format("%d,", resolved.width);
     } else {
       return String.format("%d,%d", resolved.width, resolved.height);
     }
   }
 
-  public Dimension resolve(Dimension nativeSize, ImageApiProfile profile) throws ResolvingException {
+  public Dimension resolve(Dimension nativeSize, ImageApiProfile profile)
+      throws ResolvingException {
     return resolve(nativeSize, Collections.emptyList(), profile);
   }
 
   /**
-   * Resolve the request to dimensions that can be used for scaling, based on the native size of the image region and the available profile.
+   * Resolve the request to dimensions that can be used for scaling, based on the native size of the
+   * image region and the available profile.
    *
    * @param nativeSize native size of the image region
    * @param availableSizes available sizes
    * @param profile image api profile
    * @return resolved dimension
-   * @throws de.digitalcollections.iiif.model.image.ResolvingException if params can not be resolved to Dimension
+   * @throws de.digitalcollections.iiif.model.image.ResolvingException if params can not be resolved
+   *     to Dimension
    */
-  public Dimension resolve(Dimension nativeSize, List<Dimension> availableSizes, ImageApiProfile profile) throws ResolvingException {
+  public Dimension resolve(
+      Dimension nativeSize, List<Dimension> availableSizes, ImageApiProfile profile)
+      throws ResolvingException {
     double aspect = (double) nativeSize.width / (double) nativeSize.height;
     // "max"
     if (max) {
-      // By default, identical to the largest available size or the native size if no sizes were specified
-      Dimension dim = availableSizes.stream()
-          // Avoid upscaling when dealing with region requests
-          .filter(s -> s.width <= nativeSize.width && s.height <= nativeSize.height)
-          // Select the largest available size
-          .max(Comparator.comparing(Dimension::getWidth).thenComparing(Dimension::getHeight))
-          // Otherwise, fall back to the native size
-          .orElse(new Dimension(nativeSize.width, nativeSize.height));
+      // By default, identical to the largest available size or the native size if no sizes were
+      // specified
+      Dimension dim =
+          availableSizes.stream()
+              // Avoid upscaling when dealing with region requests
+              .filter(s -> s.width <= nativeSize.width && s.height <= nativeSize.height)
+              // Select the largest available size
+              .max(Comparator.comparing(Dimension::getWidth).thenComparing(Dimension::getHeight))
+              // Otherwise, fall back to the native size
+              .orElse(new Dimension(nativeSize.width, nativeSize.height));
       if (profile != null && profile.maxWidth != null) {
         if (dim.width > profile.maxWidth) {
           // If maximum width is set, width cannot exceed it
@@ -236,16 +246,17 @@ public class SizeRequest {
           dim.width = (int) Math.sqrt(aspect * (double) profile.maxArea);
           dim.height = (int) (dim.width / aspect);
           if (dim.width <= 0 || dim.height <= 0) {
-            throw new ResolvingException(String.format(
-                "Cannot fit image with dimensions %dx%d into maximum area of %d pixels.",
-                nativeSize.width, nativeSize.height, profile.maxArea));
+            throw new ResolvingException(
+                String.format(
+                    "Cannot fit image with dimensions %dx%d into maximum area of %d pixels.",
+                    nativeSize.width, nativeSize.height, profile.maxArea));
           }
         }
       }
       return dim;
     }
     Dimension out;
-    if (percentage != null || bestFit) {  // "pct:"
+    if (percentage != null || bestFit) { // "pct:"
       double ratio;
       if (percentage != null) {
         ratio = percentage.doubleValue() / 100.0;
@@ -253,7 +264,7 @@ public class SizeRequest {
         ratio = Math.min(width / nativeSize.getWidth(), height / nativeSize.getHeight());
       }
       out = new Dimension((int) (ratio * nativeSize.width), (int) (ratio * nativeSize.height));
-    } else if (width == null && height == null) {  // "full"
+    } else if (width == null && height == null) { // "full"
       out = nativeSize;
     } else {
       out = new Dimension();
@@ -263,7 +274,7 @@ public class SizeRequest {
       if (height != null) {
         out.height = height;
       }
-      if (width == null) {  // ",h"
+      if (width == null) { // ",h"
         out.width = (int) (out.height * aspect);
       }
       if (height == null) { // "w,"
@@ -272,36 +283,43 @@ public class SizeRequest {
     }
     Integer maxHeight = profile.maxHeight != null ? profile.maxHeight : profile.maxWidth;
     if (profile.maxWidth != null && out.width > profile.maxWidth) {
-      throw new ResolvingException(String.format(
-          "Requested width (%d) exceeds maximum width (%d) as specified in the profile.", out.width, profile.maxWidth));
+      throw new ResolvingException(
+          String.format(
+              "Requested width (%d) exceeds maximum width (%d) as specified in the profile.",
+              out.width, profile.maxWidth));
     } else if (maxHeight != null && out.height > maxHeight) {
-      throw new ResolvingException(String.format(
-          "Requested height (%d) exceeds maximum height (%d) as specified in the profile.", out.height, maxHeight));
+      throw new ResolvingException(
+          String.format(
+              "Requested height (%d) exceeds maximum height (%d) as specified in the profile.",
+              out.height, maxHeight));
     } else if (profile.maxArea != null && out.height * out.width > profile.maxArea) {
-      throw new ResolvingException(String.format(
-          "Requested area (%d*%d = %d) exceeds maximum area (%d) as specified in the profile",
-          out.width, out.height, out.width * out.height, profile.maxArea));
-    } else if ((profile.features == null || !profile.features.contains(ImageApiProfile.Feature.SIZE_ABOVE_FULL))
-               && (out.width > nativeSize.width || out.height > nativeSize.height)) {
-      throw new ResolvingException(String.format(
-          "Requested dimensions (%dx%d) exceed native dimensions (%dx%d), profile states that upscaling is not supported.",
-          out.width, out.height, nativeSize.width, nativeSize.height));
+      throw new ResolvingException(
+          String.format(
+              "Requested area (%d*%d = %d) exceeds maximum area (%d) as specified in the profile",
+              out.width, out.height, out.width * out.height, profile.maxArea));
+    } else if ((profile.features == null
+            || !profile.features.contains(ImageApiProfile.Feature.SIZE_ABOVE_FULL))
+        && (out.width > nativeSize.width || out.height > nativeSize.height)) {
+      throw new ResolvingException(
+          String.format(
+              "Requested dimensions (%dx%d) exceed native dimensions (%dx%d), profile states that upscaling is not supported.",
+              out.width, out.height, nativeSize.width, nativeSize.height));
     }
     return out;
   }
 
   /**
-   * Like {@link #resolve(Dimension, ImageApiProfile)}, but can be used with a {@link Rectangle}, e.g. as returned from {@link RegionRequest#resolve(Dimension)}.
+   * Like {@link #resolve(Dimension, ImageApiProfile)}, but can be used with a {@link Rectangle},
+   * e.g. as returned from {@link RegionRequest#resolve(Dimension)}.
    *
    * @param region image region
    * @param profile image api profile
    * @return resolved size dimension
-   * @throws de.digitalcollections.iiif.model.image.ResolvingException if rectangle region can not be resolved
+   * @throws de.digitalcollections.iiif.model.image.ResolvingException if rectangle region can not
+   *     be resolved
    */
   public Dimension resolve(Rectangle region, ImageApiProfile profile) throws ResolvingException {
-    return resolve(
-        new Dimension(region.width, region.height),
-        profile);
+    return resolve(new Dimension(region.width, region.height), profile);
   }
 
   /**

--- a/src/main/java/de/digitalcollections/iiif/model/image/TileInfo.java
+++ b/src/main/java/de/digitalcollections/iiif/model/image/TileInfo.java
@@ -6,9 +6,7 @@ import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Describes an Image API tile.
- */
+/** Describes an Image API tile. */
 public class TileInfo {
 
   private Integer width;

--- a/src/main/java/de/digitalcollections/iiif/model/interfaces/Selector.java
+++ b/src/main/java/de/digitalcollections/iiif/model/interfaces/Selector.java
@@ -1,4 +1,3 @@
 package de.digitalcollections.iiif.model.interfaces;
 
-public interface Selector {
-}
+public interface Selector {}

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/DeserializerModifier.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/DeserializerModifier.java
@@ -19,8 +19,11 @@ import java.util.Arrays;
 public class DeserializerModifier extends BeanDeserializerModifier {
 
   @Override
-  public JsonDeserializer<?> modifyEnumDeserializer(DeserializationConfig config, JavaType type,
-                                                    BeanDescription beanDesc, JsonDeserializer<?> deserializer) {
+  public JsonDeserializer<?> modifyEnumDeserializer(
+      DeserializationConfig config,
+      JavaType type,
+      BeanDescription beanDesc,
+      JsonDeserializer<?> deserializer) {
     if (Arrays.asList(Quality.class, Format.class).contains(type.getRawClass())) {
       return new EnumDeserializer((Class<? extends Enum>) type.getRawClass());
     }
@@ -28,8 +31,8 @@ public class DeserializerModifier extends BeanDeserializerModifier {
   }
 
   @Override
-  public JsonDeserializer<?> modifyDeserializer(DeserializationConfig config, BeanDescription beanDesc,
-                                                JsonDeserializer<?> deserializer) {
+  public JsonDeserializer<?> modifyDeserializer(
+      DeserializationConfig config, BeanDescription beanDesc, JsonDeserializer<?> deserializer) {
     // We don't use the @JsonDeserialize annotation since we only want the
     // custom deserializer for the abstract type and not for the actual types.
     if (Service.class == beanDesc.getBeanClass()) {

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/IiifModule.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/IiifModule.java
@@ -19,11 +19,13 @@ public class IiifModule extends SimpleModule {
     this.setDeserializerModifier(new DeserializerModifier());
 
     // Just use MimeType's getTypeName and String constructor for serializing/deserializing it
-    this.addSerializer(new StdDelegatingSerializer(MimeType.class, toString(MimeType::getTypeName)));
-    this.addDeserializer(MimeType.class, new StdDelegatingDeserializer<>(fromString(MimeType::fromTypename)));
+    this.addSerializer(
+        new StdDelegatingSerializer(MimeType.class, toString(MimeType::getTypeName)));
+    this.addDeserializer(
+        MimeType.class, new StdDelegatingDeserializer<>(fromString(MimeType::fromTypename)));
   }
 
-  /** Helper function to create Converter from lambda **/
+  /** Helper function to create Converter from lambda * */
   private <T> Converter<String, T> fromString(Function<String, ? extends T> fun) {
     return new StdConverter<String, T>() {
       @Override
@@ -33,7 +35,7 @@ public class IiifModule extends SimpleModule {
     };
   }
 
-  /** Helper function to create Converter from lambda **/
+  /** Helper function to create Converter from lambda * */
   private <T> Converter<T, String> toString(Function<T, String> fun) {
     return new StdConverter<T, String>() {
       @Override

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/IiifObjectMapper.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/IiifObjectMapper.java
@@ -16,7 +16,9 @@ public class IiifObjectMapper extends ObjectMapper {
     int currentMinor = this.version().getMinorVersion();
     if (currentMajor < neededMajor || (currentMajor == neededMajor && currentMinor < neededMinor)) {
       throw new RuntimeException(
-          String.format("iiif-apis requires Jackson >= 2.9.0. The version on your classpath is %s", this.version().toString()));
+          String.format(
+              "iiif-apis requires Jackson >= 2.9.0. The version on your classpath is %s",
+              this.version().toString()));
     }
   }
 

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/ProblemHandler.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/ProblemHandler.java
@@ -22,8 +22,13 @@ import org.geojson.Feature;
 public class ProblemHandler extends DeserializationProblemHandler {
 
   @Override
-  public Object handleMissingInstantiator(DeserializationContext ctxt, Class<?> instClass, ValueInstantiator valueInsta,
-                                          JsonParser p, String msg) throws IOException {
+  public Object handleMissingInstantiator(
+      DeserializationContext ctxt,
+      Class<?> instClass,
+      ValueInstantiator valueInsta,
+      JsonParser p,
+      String msg)
+      throws IOException {
     /* FIXME: For some reason Jackson can't find the {@link Canvas(String)} constructor, so we do it ourselves:
      * 1. Check if the deserializer bails out on a JSON string
      * 2. Find a String-constructor on the target class
@@ -43,16 +48,23 @@ public class ProblemHandler extends DeserializationProblemHandler {
   }
 
   @Override
-  public Object handleUnexpectedToken(DeserializationContext ctxt, Class<?> targetType, JsonToken t, JsonParser p,
-                                      String failureMsg) throws IOException {
+  public Object handleUnexpectedToken(
+      DeserializationContext ctxt,
+      Class<?> targetType,
+      JsonToken t,
+      JsonParser p,
+      String failureMsg)
+      throws IOException {
     if (p.getCurrentName().equals("@type") && t == JsonToken.START_ARRAY) {
       // Handle multi-valued @types, only current known cases are oa:SvgSelector and oa:CssStyle
       // in combination with cnt:ContentAsText
       ObjectMapper mapper = (ObjectMapper) p.getCodec();
-      String typeName = StreamSupport.stream(((ArrayNode) mapper.readTree(p)).spliterator(), false)
-          .map(JsonNode::textValue)
-          .filter(v -> !v.equals(ContentAsText.TYPE))
-          .findFirst().orElse(null);
+      String typeName =
+          StreamSupport.stream(((ArrayNode) mapper.readTree(p)).spliterator(), false)
+              .map(JsonNode::textValue)
+              .filter(v -> !v.equals(ContentAsText.TYPE))
+              .findFirst()
+              .orElse(null);
       if (typeName != null) {
         return typeName;
       }
@@ -61,8 +73,9 @@ public class ProblemHandler extends DeserializationProblemHandler {
   }
 
   @Override
-  public JavaType handleMissingTypeId(DeserializationContext ctxt, JavaType baseType, TypeIdResolver idResolver,
-                                      String failureMsg) throws IOException {
+  public JavaType handleMissingTypeId(
+      DeserializationContext ctxt, JavaType baseType, TypeIdResolver idResolver, String failureMsg)
+      throws IOException {
     if (baseType.getRawClass() == Feature.class) {
       return idResolver.typeFromId(ctxt, "Feature");
     }
@@ -70,12 +83,15 @@ public class ProblemHandler extends DeserializationProblemHandler {
   }
 
   @Override
-  public Object handleWeirdStringValue(DeserializationContext ctxt, Class<?> targetType, String valueToConvert, String failureMsg) throws IOException {
+  public Object handleWeirdStringValue(
+      DeserializationContext ctxt, Class<?> targetType, String valueToConvert, String failureMsg)
+      throws IOException {
     if (targetType.isEnum()) {
       String lowerCased = valueToConvert.toLowerCase();
-      Optional<?> match = Arrays.stream(targetType.getEnumConstants())
-          .filter(v -> v.toString().toLowerCase().equals(valueToConvert.toLowerCase()))
-          .findFirst();
+      Optional<?> match =
+          Arrays.stream(targetType.getEnumConstants())
+              .filter(v -> v.toString().toLowerCase().equals(valueToConvert.toLowerCase()))
+              .findFirst();
       if (match.isPresent()) {
         return match.get();
       }

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/SerializerModifier.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/SerializerModifier.java
@@ -16,25 +16,29 @@ import java.util.ArrayList;
 /**
  * Modifies the serializer to support the following functions:
  *
- *  - Add the JSON-LD '@context' property with the IIIF context to the top-level object
- *  - Serialize empty Resources as null, Resources with only an @id as strings
- *  - Remove redundant `@type` from Annotation.on and certain image resources
- *  - Add custom logic for when to unwrap single values
+ * <p>- Add the JSON-LD '@context' property with the IIIF context to the top-level object -
+ * Serialize empty Resources as null, Resources with only an @id as strings - Remove redundant
+ * `@type` from Annotation.on and certain image resources - Add custom logic for when to unwrap
+ * single values
  */
 public class SerializerModifier extends BeanSerializerModifier {
 
   @Override
-  public JsonSerializer<?> modifyCollectionSerializer(SerializationConfig config, CollectionType valueType,
-                                                      BeanDescription beanDesc, JsonSerializer<?> serializer) {
+  public JsonSerializer<?> modifyCollectionSerializer(
+      SerializationConfig config,
+      CollectionType valueType,
+      BeanDescription beanDesc,
+      JsonSerializer<?> serializer) {
     if (valueType.getRawClass() == ArrayList.class) {
-      return new IiifIndexedListSerializer((IndexedListSerializer) serializer, config.getTypeFactory());
+      return new IiifIndexedListSerializer(
+          (IndexedListSerializer) serializer, config.getTypeFactory());
     }
     return super.modifyCollectionSerializer(config, valueType, beanDesc, serializer);
   }
 
   @Override
-  public JsonSerializer<?> modifySerializer(SerializationConfig config, BeanDescription beanDesc,
-                                            JsonSerializer<?> serializer) {
+  public JsonSerializer<?> modifySerializer(
+      SerializationConfig config, BeanDescription beanDesc, JsonSerializer<?> serializer) {
     if (Resource.class.isAssignableFrom(beanDesc.getBeanClass())) {
       return new ResourceSerializer((JsonSerializer<Object>) serializer);
     } else if (Profile.class.isAssignableFrom(beanDesc.getBeanClass())) {

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/package-info.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/package-info.java
@@ -1,4 +1,2 @@
-/**
- * Jackson extensions for handling IIIF JSON-LD content.
- */
+/** Jackson extensions for handling IIIF JSON-LD content. */
 package de.digitalcollections.iiif.model.jackson;

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/EnumDeserializer.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/EnumDeserializer.java
@@ -16,6 +16,7 @@ public class EnumDeserializer extends JsonDeserializer<Enum> {
 
   @Override
   public Enum deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-    return Enum.valueOf(enumType, CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, p.getValueAsString()));
+    return Enum.valueOf(
+        enumType, CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, p.getValueAsString()));
   }
 }

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/IiifIndexedListSerializer.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/IiifIndexedListSerializer.java
@@ -15,36 +15,53 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * This is a custom serializer for `List&lt;Object&gt;` that has some special cases required by
- * the IIIF specification, namely that some fields should not be encoded as arrays if
- * they only contain a single element.
+ * This is a custom serializer for `List&lt;Object&gt;` that has some special cases required by the
+ * IIIF specification, namely that some fields should not be encoded as arrays if they only contain
+ * a single element.
  *
- * Apart from this, the code is identical to {@link IndexedListSerializer} and delegates
- * to it where possible.
+ * <p>Apart from this, the code is identical to {@link IndexedListSerializer} and delegates to it
+ * where possible.
  */
 public final class IiifIndexedListSerializer extends AsArraySerializerBase<List<?>> {
 
-  private static final ImmutableSet<String> UNWRAP_FIELDS = ImmutableSet.of(
-      "service", "profile", "within", "logo", "description", "viewingHint",
-      "@type", "license", "rendering", "seeAlso", "related", "thumbnail");
+  private static final ImmutableSet<String> UNWRAP_FIELDS =
+      ImmutableSet.of(
+          "service",
+          "profile",
+          "within",
+          "logo",
+          "description",
+          "viewingHint",
+          "@type",
+          "license",
+          "rendering",
+          "seeAlso",
+          "related",
+          "thumbnail");
 
   private final IndexedListSerializer defaultSerializer;
 
   public IiifIndexedListSerializer(IndexedListSerializer defaultSerializer, TypeFactory tf) {
-    super(List.class, tf.constructSimpleType(Object.class, new JavaType[]{}), false, null, null);
+    super(List.class, tf.constructSimpleType(Object.class, new JavaType[] {}), false, null, null);
     this.defaultSerializer = defaultSerializer;
   }
 
-  private IiifIndexedListSerializer(IiifIndexedListSerializer src, BeanProperty prop,
-                                    TypeSerializer vts, JsonSerializer<?> valueSerializer,
-                                    Boolean unwrapSingle) {
+  private IiifIndexedListSerializer(
+      IiifIndexedListSerializer src,
+      BeanProperty prop,
+      TypeSerializer vts,
+      JsonSerializer<?> valueSerializer,
+      Boolean unwrapSingle) {
     super(src, prop, vts, valueSerializer, unwrapSingle);
     this.defaultSerializer = src.defaultSerializer;
   }
 
   @Override
-  public AsArraySerializerBase<List<?>> withResolved(BeanProperty property, TypeSerializer vts,
-                                                     JsonSerializer<?> elementSerializer, Boolean unwrapSingle) {
+  public AsArraySerializerBase<List<?>> withResolved(
+      BeanProperty property,
+      TypeSerializer vts,
+      JsonSerializer<?> elementSerializer,
+      Boolean unwrapSingle) {
     return new IiifIndexedListSerializer(this, property, vts, elementSerializer, unwrapSingle);
   }
 
@@ -66,9 +83,9 @@ public final class IiifIndexedListSerializer extends AsArraySerializerBase<List<
   }
 
   @Override
-  protected void serializeContents(List<?> value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+  protected void serializeContents(List<?> value, JsonGenerator gen, SerializerProvider provider)
+      throws IOException {
     defaultSerializer.serializeContents(value, gen, provider);
-
   }
 
   @Override

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/ProfileDeserializer.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/ProfileDeserializer.java
@@ -19,9 +19,11 @@ public class ProfileDeserializer extends JsonDeserializer<Profile> {
   }
 
   private boolean isImageApiProfile(final String profile) {
-    return Stream.of(ImageApiProfile.LEVEL_ZERO, ImageApiProfile.LEVEL_ONE, ImageApiProfile.LEVEL_TWO)
-        .map(p -> p.getIdentifier().toString())
-        .anyMatch(profile::equals) || ImageApiProfile.V1_PROFILES.contains(profile);
+    return Stream.of(
+                ImageApiProfile.LEVEL_ZERO, ImageApiProfile.LEVEL_ONE, ImageApiProfile.LEVEL_TWO)
+            .map(p -> p.getIdentifier().toString())
+            .anyMatch(profile::equals)
+        || ImageApiProfile.V1_PROFILES.contains(profile);
   }
 
   @Override

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/ProfileSerializer.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/ProfileSerializer.java
@@ -18,9 +18,11 @@ public class ProfileSerializer extends JsonSerializer<Profile> {
   }
 
   @Override
-  public void serialize(Profile value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+  public void serialize(Profile value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
     Completeness completeness = ModelUtilities.getCompleteness(value, Profile.class);
-    if (completeness == Completeness.ID_ONLY || (value instanceof ImageApiProfile && completeness == Completeness.ID_AND_TYPE)) {
+    if (completeness == Completeness.ID_ONLY
+        || (value instanceof ImageApiProfile && completeness == Completeness.ID_AND_TYPE)) {
       gen.writeString(value.getIdentifier().toString());
     } else {
       defaultSerializer.serialize(value, gen, serializers);

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/PropertyValueDeserializer.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/PropertyValueDeserializer.java
@@ -63,5 +63,4 @@ public class PropertyValueDeserializer extends JsonDeserializer<PropertyValue> {
       throw new IllegalArgumentException("Property values must be strings, objects or arrays");
     }
   }
-
 }

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/PropertyValueSerializer.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/PropertyValueSerializer.java
@@ -18,7 +18,8 @@ public class PropertyValueSerializer extends StdSerializer<PropertyValue> {
     super(t);
   }
 
-  private void writeSingleLocalization(JsonGenerator jgen, Locale language, String value) throws IOException {
+  private void writeSingleLocalization(JsonGenerator jgen, Locale language, String value)
+      throws IOException {
     jgen.writeStartObject();
     jgen.writeStringField("@language", language.toLanguageTag());
     jgen.writeStringField("@value", value);
@@ -26,7 +27,8 @@ public class PropertyValueSerializer extends StdSerializer<PropertyValue> {
   }
 
   @Override
-  public void serialize(PropertyValue value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+  public void serialize(PropertyValue value, JsonGenerator jgen, SerializerProvider provider)
+      throws IOException {
     if (value.getLocalizations().size() == 1 && value.getLocalizations().contains(Locale.ROOT)) {
       // Simple property value
       if (value.getValues().size() == 1) {
@@ -44,7 +46,8 @@ public class PropertyValueSerializer extends StdSerializer<PropertyValue> {
       if (localizations.size() == 1 && value.getValues().size() == 1) {
         Locale lang = localizations.iterator().next();
         this.writeSingleLocalization(jgen, lang, value.getFirstValue());
-      } else if (localizations.size() > 1 || (value.getValues() != null && value.getValues().size() > 1)) {
+      } else if (localizations.size() > 1
+          || (value.getValues() != null && value.getValues().size() > 1)) {
         jgen.writeStartArray();
         for (Locale language : localizations) {
           for (String v : value.getValues(language)) {

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/ResourceSerializer.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/ResourceSerializer.java
@@ -26,7 +26,8 @@ public class ResourceSerializer extends JsonSerializer<Resource> {
   }
 
   @Override
-  public void serialize(Resource value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+  public void serialize(Resource value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
     // Add @context to top-level object
     if (gen.getOutputContext().getParent() == null) {
       value._context = Resource.CONTEXT;
@@ -71,31 +72,39 @@ public class ResourceSerializer extends JsonSerializer<Resource> {
     }
 
     Completeness completeness = ModelUtilities.getCompleteness(value, value.getClass());
-    if (Objects.equals(containingField, "canvases") && completeness == ModelUtilities.Completeness.ID_AND_TYPE) {
-      // It's redundant to specify the @type here, since it's clear we have canvases from the field name
+    if (Objects.equals(containingField, "canvases")
+        && completeness == ModelUtilities.Completeness.ID_AND_TYPE) {
+      // It's redundant to specify the @type here, since it's clear we have canvases from the field
+      // name
       completeness = ModelUtilities.Completeness.ID_ONLY;
     }
-    if (Objects.equals(containingField, "within") && completeness == ModelUtilities.Completeness.ID_AND_TYPE) {
+    if (Objects.equals(containingField, "within")
+        && completeness == ModelUtilities.Completeness.ID_AND_TYPE) {
       // It's also redundant in these cases, since the specification prescribes a convention
       String withinType = value.getType();
-      boolean skipType = (("sc:Manifest".equals(parentType) && "sc:Collection".equals(withinType))
-          || ("sc:AnnotationList".equals(parentType) && "sc:Layer".equals(withinType))
-          || ("sc:Collection".equals(parentType) && "sc:Collection".equals(withinType)));
+      boolean skipType =
+          (("sc:Manifest".equals(parentType) && "sc:Collection".equals(withinType))
+              || ("sc:AnnotationList".equals(parentType) && "sc:Layer".equals(withinType))
+              || ("sc:Collection".equals(parentType) && "sc:Collection".equals(withinType)));
       if (skipType) {
         completeness = ModelUtilities.Completeness.ID_ONLY;
       }
-    } else if (Objects.equals(containingField, "on") && completeness == ModelUtilities.Completeness.ID_AND_TYPE) {
-      boolean skipType = (value instanceof Canvas
-          && gen.getCurrentValue() instanceof Annotation
-          && Objects.equals(((Annotation) gen.getCurrentValue()).getMotivation(), Motivation.PAINTING));
+    } else if (Objects.equals(containingField, "on")
+        && completeness == ModelUtilities.Completeness.ID_AND_TYPE) {
+      boolean skipType =
+          (value instanceof Canvas
+              && gen.getCurrentValue() instanceof Annotation
+              && Objects.equals(
+                  ((Annotation) gen.getCurrentValue()).getMotivation(), Motivation.PAINTING));
       if (skipType) {
         completeness = ModelUtilities.Completeness.ID_ONLY;
       }
     } else {
       ImmutableSet<String> skipParents = ImmutableSet.of("contentLayer", "ranges", "annotations");
-      boolean shouldSkip = (Arrays.asList("prev", "next", "first", "last").contains(containingField)
-                            || (completeness == Completeness.ID_AND_TYPE && skipParents.contains(containingField))
-                            || ("otherContent".equals(containingField) && "sc:Layer".equals(parentType)));
+      boolean shouldSkip =
+          (Arrays.asList("prev", "next", "first", "last").contains(containingField)
+              || (completeness == Completeness.ID_AND_TYPE && skipParents.contains(containingField))
+              || ("otherContent".equals(containingField) && "sc:Layer".equals(parentType)));
       if (shouldSkip) {
         completeness = Completeness.ID_ONLY;
       }

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/SelectorDeserializer.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/SelectorDeserializer.java
@@ -17,23 +17,25 @@ import java.util.stream.StreamSupport;
 
 public class SelectorDeserializer extends JsonDeserializer<Selector> {
 
-  private static final Map<String, Class<? extends Selector>> MAPPING
-      = new ImmutableMap.Builder<String, Class<? extends Selector>>()
-      .put(ImageApiSelector.TYPE, ImageApiSelector.class)
-      .put(SvgSelector.TYPE, SvgSelector.class)
-      .put(TextQuoteSelector.TYPE, TextQuoteSelector.class)
-      .build();
+  private static final Map<String, Class<? extends Selector>> MAPPING =
+      new ImmutableMap.Builder<String, Class<? extends Selector>>()
+          .put(ImageApiSelector.TYPE, ImageApiSelector.class)
+          .put(SvgSelector.TYPE, SvgSelector.class)
+          .put(TextQuoteSelector.TYPE, TextQuoteSelector.class)
+          .build();
 
-  public Selector deserialize(JsonParser p, DeserializationContext ctxt)
-      throws IOException {
+  public Selector deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
     ObjectMapper mapper = (ObjectMapper) p.getCodec();
     ObjectNode obj = mapper.readTree(p);
     String typeName;
     if (obj.get("@type").isArray()) {
       // Find the actual selector type
-      typeName = StreamSupport.stream(obj.get("@type").spliterator(), false)
-          .filter(v -> !v.textValue().equals("cnt:ContentAsText"))
-          .findFirst().orElse(new TextNode("UNKNOWN")).textValue();
+      typeName =
+          StreamSupport.stream(obj.get("@type").spliterator(), false)
+              .filter(v -> !v.textValue().equals("cnt:ContentAsText"))
+              .findFirst()
+              .orElse(new TextNode("UNKNOWN"))
+              .textValue();
       // Make @type a text value so that Jackson doesn't bail out further down the line
       obj.set("@type", new TextNode(typeName));
     } else {

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/ServiceDeserializer.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/ServiceDeserializer.java
@@ -25,11 +25,11 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-/** Custom deserializer for services.
+/**
+ * Custom deserializer for services.
  *
- * Necessary since the type dispatching is not uniform for services,
- * sometimes we can decide by looking at @context, but other times we need to look
- * at the profile or both.
+ * <p>Necessary since the type dispatching is not uniform for services, sometimes we can decide by
+ * looking at @context, but other times we need to look at the profile or both.
  */
 public class ServiceDeserializer extends JsonDeserializer<Service> {
 
@@ -89,14 +89,17 @@ public class ServiceDeserializer extends JsonDeserializer<Service> {
       service.setHeight(obj.get("height").asInt());
     }
     if (obj.has("scale_factors") && (service.getWidth() != null && service.getHeight() != null)) {
-      obj.withArray("scale_factors").forEach(
-        fnode -> service.addSize(new Size(service.getWidth() / fnode.asInt(),
-                                          service.getHeight() / fnode.asInt())));
+      obj.withArray("scale_factors")
+          .forEach(
+              fnode ->
+                  service.addSize(
+                      new Size(
+                          service.getWidth() / fnode.asInt(),
+                          service.getHeight() / fnode.asInt())));
     }
     if (obj.has("tile_width") && obj.has("scale_factors")) {
       TileInfo tinfo = new TileInfo(obj.get("tile_width").asInt());
-      obj.withArray("scale_factors").forEach(
-        fnode -> tinfo.addScaleFactor(fnode.asInt()));
+      obj.withArray("scale_factors").forEach(fnode -> tinfo.addScaleFactor(fnode.asInt()));
       if (obj.has("tile_height")) {
         tinfo.setHeight(obj.get("tile_height").intValue());
       }
@@ -105,16 +108,18 @@ public class ServiceDeserializer extends JsonDeserializer<Service> {
     if (obj.has("formats") || obj.has("qualities")) {
       ImageApiProfile profile = new ImageApiProfile();
       if (obj.has("formats")) {
-        obj.withArray("formats").forEach(
-          f -> profile.addFormat(ImageApiProfile.Format.valueOf(f.asText().toUpperCase())));
+        obj.withArray("formats")
+            .forEach(
+                f -> profile.addFormat(ImageApiProfile.Format.valueOf(f.asText().toUpperCase())));
       }
       if (obj.has("qualities")) {
-        List<String> qualities = StreamSupport.stream(
-          obj.withArray("qualities").spliterator(), false)
-              .map(q -> q.asText().equals("native") ? "default" : q.asText())
-              .map(q -> q.equals("grey") ? "gray" : q)
-              .collect(Collectors.toList());
-        qualities.forEach(q -> profile.addQuality(ImageApiProfile.Quality.valueOf(q.toUpperCase())));
+        List<String> qualities =
+            StreamSupport.stream(obj.withArray("qualities").spliterator(), false)
+                .map(q -> q.asText().equals("native") ? "default" : q.asText())
+                .map(q -> q.equals("grey") ? "gray" : q)
+                .collect(Collectors.toList());
+        qualities.forEach(
+            q -> profile.addQuality(ImageApiProfile.Quality.valueOf(q.toUpperCase())));
       }
       service.addProfile(profile);
     }

--- a/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/package-info.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/package-info.java
@@ -1,4 +1,2 @@
-/**
- * Custom serializers and deserializers for IIIF entities.
- */
+/** Custom serializers and deserializers for IIIF entities. */
 package de.digitalcollections.iiif.model.jackson.serialization;

--- a/src/main/java/de/digitalcollections/iiif/model/openannotation/Annotation.java
+++ b/src/main/java/de/digitalcollections/iiif/model/openannotation/Annotation.java
@@ -9,10 +9,11 @@ import de.digitalcollections.iiif.model.sharedcanvas.Resource;
 /**
  * An OpenAnnotation Annotation.
  *
- * Content resources and commentary are associated with a canvas via an annotation. This provides a single, coherent
- * method for aligning information, and provides a standards based framework for distinguishing parts of resources and
- * parts of canvases. As annotations can be added later, it promotes a distributed system in which publishers can align
- * their content with the descriptions created by others.
+ * <p>Content resources and commentary are associated with a canvas via an annotation. This provides
+ * a single, coherent method for aligning information, and provides a standards based framework for
+ * distinguishing parts of resources and parts of canvases. As annotations can be added later, it
+ * promotes a distributed system in which publishers can align their content with the descriptions
+ * created by others.
  */
 @JsonPropertyOrder({"@context", "@id", "@type", "motivation", "resource", "on"})
 public class Annotation extends Resource<Annotation> {

--- a/src/main/java/de/digitalcollections/iiif/model/openannotation/ContentAsText.java
+++ b/src/main/java/de/digitalcollections/iiif/model/openannotation/ContentAsText.java
@@ -10,9 +10,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-/**
- * A resource that contains embedded textual content.
- */
+/** A resource that contains embedded textual content. */
 public class ContentAsText extends Resource<ContentAsText> {
 
   public static final String TYPE = "cnt:ContentAsText";

--- a/src/main/java/de/digitalcollections/iiif/model/openannotation/CssStyle.java
+++ b/src/main/java/de/digitalcollections/iiif/model/openannotation/CssStyle.java
@@ -7,9 +7,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * A resource that contains embedded CSS Stylesheet definitions
- */
+/** A resource that contains embedded CSS Stylesheet definitions */
 public class CssStyle extends ContentAsText {
 
   public static final String TYPE = "oa:CssStyle";

--- a/src/main/java/de/digitalcollections/iiif/model/openannotation/SpecificResource.java
+++ b/src/main/java/de/digitalcollections/iiif/model/openannotation/SpecificResource.java
@@ -8,10 +8,8 @@ import de.digitalcollections.iiif.model.sharedcanvas.Resource;
 /**
  * A resource that applies complex styles and/or selectors to a given resource.
  *
- * See:
- * - http://iiif.io/api/presentation/2.1/#non-rectangular-segments
- * - http://iiif.io/api/presentation/2.1/#style
- * - http://iiif.io/api/presentation/2.1/#rotation
+ * <p>See: - http://iiif.io/api/presentation/2.1/#non-rectangular-segments -
+ * http://iiif.io/api/presentation/2.1/#style - http://iiif.io/api/presentation/2.1/#rotation
  */
 public class SpecificResource extends Resource<SpecificResource> {
 
@@ -23,8 +21,7 @@ public class SpecificResource extends Resource<SpecificResource> {
   @JsonDeserialize(using = SelectorDeserializer.class)
   private Selector selector;
 
-  public SpecificResource() {
-  }
+  public SpecificResource() {}
 
   public SpecificResource(String identifier) {
     super(identifier);

--- a/src/main/java/de/digitalcollections/iiif/model/openannotation/SvgSelector.java
+++ b/src/main/java/de/digitalcollections/iiif/model/openannotation/SvgSelector.java
@@ -3,9 +3,7 @@ package de.digitalcollections.iiif.model.openannotation;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import de.digitalcollections.iiif.model.interfaces.Selector;
 
-/**
- * A selector that selects a region of an image using SVG.
- */
+/** A selector that selects a region of an image using SVG. */
 @JsonTypeName(SvgSelector.TYPE)
 public class SvgSelector extends ContentAsText implements Selector {
 

--- a/src/main/java/de/digitalcollections/iiif/model/openannotation/package-info.java
+++ b/src/main/java/de/digitalcollections/iiif/model/openannotation/package-info.java
@@ -1,4 +1,5 @@
 /**
- * Model classes that represent entities from the OpenAnnotation specification that are used in IIIF.
+ * Model classes that represent entities from the OpenAnnotation specification that are used in
+ * IIIF.
  */
 package de.digitalcollections.iiif.model.openannotation;

--- a/src/main/java/de/digitalcollections/iiif/model/package-info.java
+++ b/src/main/java/de/digitalcollections/iiif/model/package-info.java
@@ -1,11 +1,12 @@
 /**
- * The packages contained in this module allow the usage of all parts of the IIIF specification.
- * The classes are named after the corresponding IIIF entities.
+ * The packages contained in this module allow the usage of all parts of the IIIF specification. The
+ * classes are named after the corresponding IIIF entities.
  *
- * To ensure that the resulting JSON is compliant with the IIIF specification, it is necessary
- * to use the contained Jackson object mapper ({@link de.digitalcollections.iiif.model.jackson.IiifObjectMapper}),
- * merely using the {@link de.digitalcollections.iiif.model.jackson.IiifModule} is not sufficient,
- * since a lot of custom code was necessary to achieve compliance, more than what is available
- * with Jackson modules. If you want to override or extend the settings, just subclass the ObjectMapper.
+ * <p>To ensure that the resulting JSON is compliant with the IIIF specification, it is necessary to
+ * use the contained Jackson object mapper ({@link
+ * de.digitalcollections.iiif.model.jackson.IiifObjectMapper}), merely using the {@link
+ * de.digitalcollections.iiif.model.jackson.IiifModule} is not sufficient, since a lot of custom
+ * code was necessary to achieve compliance, more than what is available with Jackson modules. If
+ * you want to override or extend the settings, just subclass the ObjectMapper.
  */
 package de.digitalcollections.iiif.model;

--- a/src/main/java/de/digitalcollections/iiif/model/search/AutocompleteService.java
+++ b/src/main/java/de/digitalcollections/iiif/model/search/AutocompleteService.java
@@ -8,7 +8,7 @@ import java.net.URI;
 /**
  * A service that describes an endpoint where autocomplete can be performed.
  *
- * See http://iiif.io/api/search/1.0/#autocomplete
+ * <p>See http://iiif.io/api/search/1.0/#autocomplete
  */
 public class AutocompleteService extends Service {
 

--- a/src/main/java/de/digitalcollections/iiif/model/search/ContentSearchService.java
+++ b/src/main/java/de/digitalcollections/iiif/model/search/ContentSearchService.java
@@ -6,9 +6,10 @@ import de.digitalcollections.iiif.model.Service;
 import java.net.URI;
 
 /**
- * A service that describes and endpoint that can be used to perform a search over the contents of a IIIF resource.
+ * A service that describes and endpoint that can be used to perform a search over the contents of a
+ * IIIF resource.
  *
- * See http://iiif.io/api/search/1.0/#search
+ * <p>See http://iiif.io/api/search/1.0/#search
  */
 public class ContentSearchService extends Service {
 

--- a/src/main/java/de/digitalcollections/iiif/model/search/SearchHit.java
+++ b/src/main/java/de/digitalcollections/iiif/model/search/SearchHit.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * Describes a search hit on a single annotation or across multiple annotations.
  *
- * See http://iiif.io/api/search/1.0/#search-api-specific-responses
+ * <p>See http://iiif.io/api/search/1.0/#search-api-specific-responses
  */
 public class SearchHit {
 

--- a/src/main/java/de/digitalcollections/iiif/model/search/SearchLayer.java
+++ b/src/main/java/de/digitalcollections/iiif/model/search/SearchLayer.java
@@ -9,7 +9,7 @@ import java.util.Set;
 /**
  * The container for all pages of a paginated page response.
  *
- * http://iiif.io/api/search/1.0/#paging-results
+ * <p>http://iiif.io/api/search/1.0/#paging-results
  */
 public class SearchLayer extends Layer {
 

--- a/src/main/java/de/digitalcollections/iiif/model/search/SearchResult.java
+++ b/src/main/java/de/digitalcollections/iiif/model/search/SearchResult.java
@@ -13,7 +13,7 @@ import java.util.List;
 /**
  * An AnnotationList that contains hits for a given search query.
  *
- * See http://iiif.io/api/search/1.0/#simple-lists
+ * <p>See http://iiif.io/api/search/1.0/#simple-lists
  */
 public class SearchResult extends AnnotationList {
 
@@ -72,7 +72,8 @@ public class SearchResult extends AnnotationList {
    */
   @Override
   public SearchResult addWithin(Resource first, Resource... rest) throws IllegalArgumentException {
-    if (!(first instanceof SearchLayer) || Arrays.stream(rest).anyMatch(r -> !(r instanceof SearchLayer))) {
+    if (!(first instanceof SearchLayer)
+        || Arrays.stream(rest).anyMatch(r -> !(r instanceof SearchLayer))) {
       throw new IllegalArgumentException("SearchResult can only be within a SearchLayer.");
     }
     super.addWithin(first, rest);

--- a/src/main/java/de/digitalcollections/iiif/model/search/Term.java
+++ b/src/main/java/de/digitalcollections/iiif/model/search/Term.java
@@ -9,7 +9,7 @@ import java.net.URI;
 /**
  * A term in an autocomplete query response.
  *
- * See http://iiif.io/api/search/1.0/#response
+ * <p>See http://iiif.io/api/search/1.0/#response
  */
 public class Term {
 

--- a/src/main/java/de/digitalcollections/iiif/model/search/TermList.java
+++ b/src/main/java/de/digitalcollections/iiif/model/search/TermList.java
@@ -12,7 +12,7 @@ import java.util.Set;
 /**
  * A list of result terms for an autocomplete query.
  *
- * See http://iiif.io/api/search/1.0/#response
+ * <p>See http://iiif.io/api/search/1.0/#response
  */
 public class TermList {
 

--- a/src/main/java/de/digitalcollections/iiif/model/search/TextQuoteSelector.java
+++ b/src/main/java/de/digitalcollections/iiif/model/search/TextQuoteSelector.java
@@ -7,7 +7,7 @@ import de.digitalcollections.iiif.model.interfaces.Selector;
 /**
  * A selector for highlighting parts of a text.
  *
- * See http://iiif.io/api/search/1.0/#search-term-highlighting
+ * <p>See http://iiif.io/api/search/1.0/#search-term-highlighting
  */
 public class TextQuoteSelector implements Selector {
 

--- a/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/AnnotationList.java
+++ b/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/AnnotationList.java
@@ -11,13 +11,13 @@ import java.util.List;
 /**
  * An ordered list of annotation lists.
  *
- * Layers allow higher level groupings of annotations to be recorded. For example, all of the English translation
- * annotations of a medieval French document could be kept separate from the transcription or an edition in modern
- * French.
+ * <p>Layers allow higher level groupings of annotations to be recorded. For example, all of the
+ * English translation annotations of a medieval French document could be kept separate from the
+ * transcription or an edition in modern French.
  *
- * May be paged, see http://iiif.io/api/presentation/2.1/#paging
+ * <p>May be paged, see http://iiif.io/api/presentation/2.1/#paging
  *
- * See http://iiif.io/api/presentation/2.1/#annotation-list
+ * <p>See http://iiif.io/api/presentation/2.1/#annotation-list
  */
 public class AnnotationList extends Resource<Annotation> implements Pageable<AnnotationList> {
 

--- a/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/Canvas.java
+++ b/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/Canvas.java
@@ -19,13 +19,15 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * A virtual container that represents a page or view and has content resources associated with it or with parts of it.
+ * A virtual container that represents a page or view and has content resources associated with it
+ * or with parts of it.
  *
- * The canvas provides a frame of reference for the layout of the content. The concept of a canvas is borrowed from
- * standards like PDF and HTML, or applications like Photoshop and Powerpoint, where the display starts from a blank
- * canvas and images, text and other resources are “painted” on to it.
+ * <p>The canvas provides a frame of reference for the layout of the content. The concept of a
+ * canvas is borrowed from standards like PDF and HTML, or applications like Photoshop and
+ * Powerpoint, where the display starts from a blank canvas and images, text and other resources are
+ * “painted” on to it.
  *
- * See http://iiif.io/api/presentation/2.1/#canvas
+ * <p>See http://iiif.io/api/presentation/2.1/#canvas
  */
 public class Canvas extends Resource<Canvas> {
 
@@ -59,7 +61,8 @@ public class Canvas extends Resource<Canvas> {
    * Sets the image annotations on this canvas. Must all be instances of {@link ImageContent}
    *
    * @param images image annotations on this canvas
-   * @throws IllegalArgumentException if at least one of the image annotations is not an {@link ImageContent}
+   * @throws IllegalArgumentException if at least one of the image annotations is not an {@link
+   *     ImageContent}
    */
   public void setImages(List<Annotation> images) throws IllegalArgumentException {
     this.images = images;
@@ -95,9 +98,8 @@ public class Canvas extends Resource<Canvas> {
       this.images = new ArrayList<>();
     }
     this.images.add(wrapImageInAnnotation(first));
-    this.images.addAll(Arrays.stream(rest)
-         .map(this::wrapImageInAnnotation)
-         .collect(Collectors.toList()));
+    this.images.addAll(
+        Arrays.stream(rest).map(this::wrapImageInAnnotation).collect(Collectors.toList()));
     // If we only have one image, set width/height from the image content by default
     if (this.images.size() == 1 && this.getWidth() == null && this.getHeight() == null) {
       this.setWidthFromImage(this.images.get(0));

--- a/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/Collection.java
+++ b/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/Collection.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.model.sharedcanvas;
 
+import static java.util.Arrays.stream;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -15,18 +17,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import static java.util.Arrays.stream;
-
 /**
  * An ordered list of manifests, and/or further collections.
  *
- * Collections allow easy advertising and browsing of the manifests in a hierarchical structure, potentially with its
- * own descriptive information. They can also provide clients with a means to locate all of the manifests known to the
- * publishing institution.
+ * <p>Collections allow easy advertising and browsing of the manifests in a hierarchical structure,
+ * potentially with its own descriptive information. They can also provide clients with a means to
+ * locate all of the manifests known to the publishing institution.
  *
- * See http://iiif.io/api/presentation/2.1/#collection
+ * <p>See http://iiif.io/api/presentation/2.1/#collection
  */
-public class Collection extends Resource<Collection> implements Pageable<Collection>, PageContainer<Collection> {
+public class Collection extends Resource<Collection>
+    implements Pageable<Collection>, PageContainer<Collection> {
 
   public static final String TYPE = "sc:Collection";
 
@@ -123,18 +124,20 @@ public class Collection extends Resource<Collection> implements Pageable<Collect
         throw new IllegalArgumentException("Collection members must have a viewingHint.");
       }
     } else if (!(member instanceof Manifest)) {
-      throw new IllegalArgumentException("Members must be either Manifest or Collection resources.");
+      throw new IllegalArgumentException(
+          "Members must be either Manifest or Collection resources.");
     }
   }
 
   /**
-   * Set the list of member resources.
-   * Must be either instances of {@link Manifest} or {@link Collection}.
-   * All {@link Collection} members must have at least one {@link de.digitalcollections.iiif.model.enums.ViewingHint}.
+   * Set the list of member resources. Must be either instances of {@link Manifest} or {@link
+   * Collection}. All {@link Collection} members must have at least one {@link
+   * de.digitalcollections.iiif.model.enums.ViewingHint}.
    *
    * @param members member resources
-   * @throws IllegalArgumentException if at least one member is not a {@link Manifest} or {@link Collection} or is a
-   *         {@link Collection} and does not have at least one {@link de.digitalcollections.iiif.model.enums.ViewingHint}
+   * @throws IllegalArgumentException if at least one member is not a {@link Manifest} or {@link
+   *     Collection} or is a {@link Collection} and does not have at least one {@link
+   *     de.digitalcollections.iiif.model.enums.ViewingHint}
    */
   public void setMembers(List<Resource> members) {
     members.forEach(this::checkMember);
@@ -142,15 +145,16 @@ public class Collection extends Resource<Collection> implements Pageable<Collect
   }
 
   /**
-   * Adds one or more member resources.
-   * Must be either instances of {@link Manifest} or {@link Collection}.
-   * All {@link Collection} members must have at least one {@link de.digitalcollections.iiif.model.enums.ViewingHint}.
+   * Adds one or more member resources. Must be either instances of {@link Manifest} or {@link
+   * Collection}. All {@link Collection} members must have at least one {@link
+   * de.digitalcollections.iiif.model.enums.ViewingHint}.
    *
    * @param first first member
    * @param rest other members
    * @return this collection with added members
-   * @throws IllegalArgumentException if at least one member is not a {@link Manifest} or {@link Collection} or is a
-   *         {@link Collection} and does not have at least one {@link de.digitalcollections.iiif.model.enums.ViewingHint}
+   * @throws IllegalArgumentException if at least one member is not a {@link Manifest} or {@link
+   *     Collection} or is a {@link Collection} and does not have at least one {@link
+   *     de.digitalcollections.iiif.model.enums.ViewingHint}
    */
   public Collection addMember(Resource first, Resource... rest) {
     if (this.members == null) {
@@ -188,7 +192,6 @@ public class Collection extends Resource<Collection> implements Pageable<Collect
   @Override
   public void setLast(Collection last) {
     this.lastPage = last;
-
   }
 
   @Override
@@ -230,5 +233,4 @@ public class Collection extends Resource<Collection> implements Pageable<Collect
   public void setStartIndex(int startIndex) {
     this.startIndex = startIndex;
   }
-
 }

--- a/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/Layer.java
+++ b/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/Layer.java
@@ -12,11 +12,11 @@ import java.util.List;
 /**
  * An ordered list of annotation lists.
  *
- * Layers allow higher level groupings of annotations to be recorded. For example, all of the English translation
- * annotations of a medieval French document could be kept separate from the transcription or an edition in modern
- * French.
+ * <p>Layers allow higher level groupings of annotations to be recorded. For example, all of the
+ * English translation annotations of a medieval French document could be kept separate from the
+ * transcription or an edition in modern French.
  *
- * See http://iiif.io/api/presentation/2.1/#layer
+ * <p>See http://iiif.io/api/presentation/2.1/#layer
  */
 public class Layer extends Resource<Layer> implements PageContainer<AnnotationList> {
 
@@ -32,6 +32,7 @@ public class Layer extends Resource<Layer> implements PageContainer<AnnotationLi
 
   @JsonProperty("total")
   private Integer totalAnnotations;
+
   private List<AnnotationList> otherContent;
 
   @JsonCreator
@@ -44,8 +45,7 @@ public class Layer extends Resource<Layer> implements PageContainer<AnnotationLi
     this.addLabel(label);
   }
 
-  public Layer() {
-  }
+  public Layer() {}
 
   @Override
   public String getType() {
@@ -69,8 +69,9 @@ public class Layer extends Resource<Layer> implements PageContainer<AnnotationLi
   }
 
   public Layer addOtherContent(String first, String... rest) {
-    return this.addOtherContent(new AnnotationList(first),
-                                Arrays.stream(rest).map(AnnotationList::new).toArray(AnnotationList[]::new));
+    return this.addOtherContent(
+        new AnnotationList(first),
+        Arrays.stream(rest).map(AnnotationList::new).toArray(AnnotationList[]::new));
   }
 
   public Layer addOtherContent(AnnotationList first, AnnotationList... rest) {
@@ -99,7 +100,6 @@ public class Layer extends Resource<Layer> implements PageContainer<AnnotationLi
   @Override
   public void setLast(AnnotationList last) {
     this.lastAnnotationPage = last;
-
   }
 
   @Override

--- a/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/Manifest.java
+++ b/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/Manifest.java
@@ -14,17 +14,33 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * The overall description of the structure and properties of the digital representation of an object.
+ * The overall description of the structure and properties of the digital representation of an
+ * object.
  *
- * It carries information needed for the viewer to present the digitized content to the user, such as a title and other
- * descriptive information about the object or the intellectual work that it conveys. Each manifest describes how to
- * present a single object such as a book, a photograph, or a statue.
+ * <p>It carries information needed for the viewer to present the digitized content to the user,
+ * such as a title and other descriptive information about the object or the intellectual work that
+ * it conveys. Each manifest describes how to present a single object such as a book, a photograph,
+ * or a statue.
  *
- * See http://iiif.io/api/presentation/2.1/#manifest
+ * <p>See http://iiif.io/api/presentation/2.1/#manifest
  */
-@JsonPropertyOrder({"@context", "@type", "@id", "label", "metadata", "description", "navDate",
-                    "license", "attribution", "service", "seeAlso", "rendering", "within",
-                    "sequences", "structures"})
+@JsonPropertyOrder({
+  "@context",
+  "@type",
+  "@id",
+  "label",
+  "metadata",
+  "description",
+  "navDate",
+  "license",
+  "attribution",
+  "service",
+  "seeAlso",
+  "rendering",
+  "within",
+  "sequences",
+  "structures"
+})
 public class Manifest extends Resource<Manifest> {
 
   public static final String TYPE = "sc:Manifest";

--- a/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/Range.java
+++ b/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/Range.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.model.sharedcanvas;
 
+import static java.util.Arrays.stream;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -15,17 +17,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import static java.util.Arrays.stream;
-
 /**
  * An ordered list of canvases, and/or further ranges.
  *
- * Ranges allow canvases, or parts thereof, to be grouped together in some way. This could be for textual reasons, such
- * as to distinguish books, chapters, verses, sections, non-content-bearing pages, the table of contents or similar.
- * Equally, physical features might be important such as quires or gatherings, sections that have been added later and
- * so forth.
+ * <p>Ranges allow canvases, or parts thereof, to be grouped together in some way. This could be for
+ * textual reasons, such as to distinguish books, chapters, verses, sections, non-content-bearing
+ * pages, the table of contents or similar. Equally, physical features might be important such as
+ * quires or gatherings, sections that have been added later and so forth.
  *
- * See http://iiif.io/api/presentation/2.1/#range
+ * <p>See http://iiif.io/api/presentation/2.1/#range
  */
 public class Range extends Resource<Range> {
 
@@ -97,7 +97,7 @@ public class Range extends Resource<Range> {
     if (completeness != Completeness.ID_AND_TYPE && completeness != Completeness.ID_ONLY) {
       throw new IllegalArgumentException(
           "Member resource must only have an identifier and no other field."
-        + " Use add<Resource>(URI first, URI... rest) for convenience.");
+              + " Use add<Resource>(URI first, URI... rest) for convenience.");
     }
   }
 
@@ -117,8 +117,8 @@ public class Range extends Resource<Range> {
   }
 
   public Range addCanvas(String idOfFirst, String... idsOfRest) {
-    return this.addCanvas(new Canvas(idOfFirst),
-                          Arrays.stream(idsOfRest).map(Canvas::new).toArray(Canvas[]::new));
+    return this.addCanvas(
+        new Canvas(idOfFirst), Arrays.stream(idsOfRest).map(Canvas::new).toArray(Canvas[]::new));
   }
 
   public List<Range> getRanges() {
@@ -141,8 +141,8 @@ public class Range extends Resource<Range> {
   }
 
   public Range addRange(String first, String... rest) {
-    return this.addRange(new Range(first),
-                         Arrays.stream(rest).map(Range::new).toArray(Range[]::new));
+    return this.addRange(
+        new Range(first), Arrays.stream(rest).map(Range::new).toArray(Range[]::new));
   }
 
   public List<Resource> getMembers() {
@@ -153,19 +153,21 @@ public class Range extends Resource<Range> {
     if (!(res instanceof Range) && !(res instanceof Canvas)) {
       throw new IllegalArgumentException("Member resources must be either of type Range or Canvas");
     }
-    if (res.getIdentifier() == null || res.getLabel() == null || res.getLabel().getValues().isEmpty()) {
-      throw new IllegalArgumentException("Member resources must have identifier, type and label set.");
+    if (res.getIdentifier() == null
+        || res.getLabel() == null
+        || res.getLabel().getValues().isEmpty()) {
+      throw new IllegalArgumentException(
+          "Member resources must have identifier, type and label set.");
     }
   }
 
   /**
-   * Sets the member resources.
-   * Must be either instances of {@link Range} or {@link Canvas}.
-   * All members must have an identifier and a label.
+   * Sets the member resources. Must be either instances of {@link Range} or {@link Canvas}. All
+   * members must have an identifier and a label.
    *
    * @param members member resources
-   * @throws IllegalArgumentException if at least one member is not a {@link Range} or {@link Canvas} or does not have
-   *         an identifier and a label;
+   * @throws IllegalArgumentException if at least one member is not a {@link Range} or {@link
+   *     Canvas} or does not have an identifier and a label;
    */
   public void setMembers(List<Resource> members) {
     members.forEach(this::checkMember);
@@ -173,15 +175,14 @@ public class Range extends Resource<Range> {
   }
 
   /**
-   * Adds one or more member resources.
-   * Must be either instances of {@link Range} or {@link Canvas}.
+   * Adds one or more member resources. Must be either instances of {@link Range} or {@link Canvas}.
    * All members must have an identifier and a label.
    *
    * @param first first member
    * @param rest other members
    * @return this instance with added members
-   * @throws IllegalArgumentException if at least one member is not a {@link Range} or {@link Canvas} or does not have
-   *         an identifier and a label;
+   * @throws IllegalArgumentException if at least one member is not a {@link Range} or {@link
+   *     Canvas} or does not have an identifier and a label;
    */
   public Range addMember(Resource first, Resource... rest) throws IllegalArgumentException {
     if (this.members == null) {

--- a/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/Resource.java
+++ b/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/Resource.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.model.sharedcanvas;
 
+import static com.google.common.collect.Lists.asList;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -20,20 +22,30 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import static com.google.common.collect.Lists.asList;
-
 /**
  * Abstract IIIF resource, most other resources are based on this.
  *
  * @param <T> a resource type, e.g. Canvas, Annotation
  */
-@JsonPropertyOrder({"@context", "@id", "@type", "label", "description", "metadata", "thumbnail", "service"})
+@JsonPropertyOrder({
+  "@context",
+  "@id",
+  "@type",
+  "label",
+  "description",
+  "metadata",
+  "thumbnail",
+  "service"
+})
 public abstract class Resource<T> implements Choice<T> {
 
   public static final String CONTEXT = "http://iiif.io/api/presentation/2/context.json";
 
-  /** Only used during serialization,
-   *  @see SerializerModifier **/
+  /**
+   * Only used during serialization,
+   *
+   * @see SerializerModifier *
+   */
   @SuppressWarnings("checkstyle:membername")
   @JsonProperty("@context")
   public String _context;
@@ -45,11 +57,9 @@ public abstract class Resource<T> implements Choice<T> {
 
   private PropertyValue description;
 
-  @JsonIgnore
-  private boolean isDefault;
+  @JsonIgnore private boolean isDefault;
 
-  @JsonIgnore
-  private List<T> alternatives;
+  @JsonIgnore private List<T> alternatives;
 
   @JsonProperty("service")
   private List<Service> services;
@@ -98,7 +108,7 @@ public abstract class Resource<T> implements Choice<T> {
 
   @JsonProperty("@type")
   public String getType() {
-    return null;  // Does not have a type
+    return null; // Does not have a type
   }
 
   public URI getIdentifier() {
@@ -303,12 +313,14 @@ public abstract class Resource<T> implements Choice<T> {
    */
   public void setViewingHints(List<ViewingHint> viewingHints) throws IllegalArgumentException {
     for (ViewingHint hint : viewingHints) {
-      boolean supportsHint = (hint.getType() == ViewingHint.Type.OTHER
-                              || this.getSupportedViewingHintTypes().contains(hint.getType()));
+      boolean supportsHint =
+          (hint.getType() == ViewingHint.Type.OTHER
+              || this.getSupportedViewingHintTypes().contains(hint.getType()));
       if (!supportsHint) {
-        throw new IllegalArgumentException(String.format(
-            "Resources of type '%s' do not support the '%s' viewing hint.",
-            this.getType(), hint.toString()));
+        throw new IllegalArgumentException(
+            String.format(
+                "Resources of type '%s' do not support the '%s' viewing hint.",
+                this.getType(), hint.toString()));
       }
     }
     this.viewingHints = viewingHints;
@@ -322,7 +334,8 @@ public abstract class Resource<T> implements Choice<T> {
    * @return this resource with added viewing hints
    * @throws IllegalArgumentException if the resources not not support one of the viewing hints.
    */
-  public Resource addViewingHint(ViewingHint first, ViewingHint... rest) throws IllegalArgumentException {
+  public Resource addViewingHint(ViewingHint first, ViewingHint... rest)
+      throws IllegalArgumentException {
     List<ViewingHint> hints = this.viewingHints;
     if (hints == null) {
       hints = new ArrayList<>();
@@ -356,7 +369,8 @@ public abstract class Resource<T> implements Choice<T> {
    * Sets the renderings. All renderings must have both a profile and a format.
    *
    * @param renderings list of renderings with profile and format
-   * @throws IllegalArgumentException if at least one rendering does not have both a profile and a format.
+   * @throws IllegalArgumentException if at least one rendering does not have both a profile and a
+   *     format.
    */
   public void setRenderings(List<OtherContent> renderings) throws IllegalArgumentException {
     renderings.forEach(this::verifyRendering);
@@ -369,7 +383,8 @@ public abstract class Resource<T> implements Choice<T> {
    * @param first first rendering
    * @param rest list of other renderings
    * @return current instance
-   * @throws IllegalArgumentException if at least one rendering does not have both a profile and a format.
+   * @throws IllegalArgumentException if at least one rendering does not have both a profile and a
+   *     format.
    */
   public Resource addRendering(OtherContent first, OtherContent... rest) {
     if (renderings == null) {

--- a/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/Sequence.java
+++ b/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/Sequence.java
@@ -15,10 +15,11 @@ import java.util.Set;
 /**
  * The order of the views of the object.
  *
- * Multiple sequences are allowed to cover situations when there are multiple equally valid orders through the content,
- * such as when a manuscript’s pages are rebound or archival collections are reordered.
+ * <p>Multiple sequences are allowed to cover situations when there are multiple equally valid
+ * orders through the content, such as when a manuscript’s pages are rebound or archival collections
+ * are reordered.
  *
- * See http://iiif.io/api/presentation/2.1/#sequence
+ * <p>See http://iiif.io/api/presentation/2.1/#sequence
  */
 public class Sequence extends Resource<Sequence> {
 

--- a/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/package-info.java
+++ b/src/main/java/de/digitalcollections/iiif/model/sharedcanvas/package-info.java
@@ -1,4 +1,5 @@
 /**
- * Model classes that represent entities from the IIIF Shared Canvas model (http://iiif.io/api/presentation/2.1/#resource-type-overview).
+ * Model classes that represent entities from the IIIF Shared Canvas model
+ * (http://iiif.io/api/presentation/2.1/#resource-type-overview).
  */
 package de.digitalcollections.iiif.model.sharedcanvas;

--- a/src/test/java/de/digitalcollections/iiif/model/ExternalTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/ExternalTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import de.digitalcollections.iiif.model.image.ImageApiProfile;
@@ -12,11 +14,7 @@ import java.util.Locale;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * Tests with real-world IIIF resources from the wild.
- */
+/** Tests with real-world IIIF resources from the wild. */
 public class ExternalTest {
 
   private ObjectMapper mapper;
@@ -27,13 +25,13 @@ public class ExternalTest {
   }
 
   private <T> T readFromResources(String filename, Class<T> clz) throws IOException {
-    return mapper.readValue(
-      Resources.getResource("external/" + filename), clz);
+    return mapper.readValue(Resources.getResource("external/" + filename), clz);
   }
 
   @Test
   public void testBiblissima() throws Exception {
-    Manifest manifest = readFromResources("biblissima_ark:12148_btv1b9007608v.json", Manifest.class);
+    Manifest manifest =
+        readFromResources("biblissima_ark:12148_btv1b9007608v.json", Manifest.class);
     assertThat(manifest).isNotNull();
   }
 
@@ -42,27 +40,31 @@ public class ExternalTest {
     Manifest manifest = readFromResources("biblissima_reconstructed.json", Manifest.class);
     // Two images per canvas, one page the other miniature
     assertThat(manifest.getDefaultSequence().getCanvases())
-      .allMatch(c -> c.getImages().size() == 2);
+        .allMatch(c -> c.getImages().size() == 2);
   }
 
   @Test
   public void testThumbnailForV1Manifest() throws Exception {
     Manifest manifest = readFromResources("yale_decretum.json", Manifest.class);
     assertThat(manifest).isNotNull();
-    ImageService service = manifest.getDefaultSequence().getCanvases().get(0).getImages().stream()
-      .map(a -> (ImageContent) a.getResource())
-      .flatMap(r -> r.getServices().stream())
-      .filter(ImageService.class::isInstance)
-      .map(ImageService.class::cast)
-      .findFirst().orElse(null);
+    ImageService service =
+        manifest.getDefaultSequence().getCanvases().get(0).getImages().stream()
+            .map(a -> (ImageContent) a.getResource())
+            .flatMap(r -> r.getServices().stream())
+            .filter(ImageService.class::isInstance)
+            .map(ImageService.class::cast)
+            .findFirst()
+            .orElse(null);
     ImageContent thumb;
-    boolean isV1 = service.getProfiles().stream()
-      .map(p -> p.getIdentifier().toString())
-      .anyMatch(ImageApiProfile.V1_PROFILES::contains);
+    boolean isV1 =
+        service.getProfiles().stream()
+            .map(p -> p.getIdentifier().toString())
+            .anyMatch(ImageApiProfile.V1_PROFILES::contains);
     if (isV1) {
       thumb = new ImageContent(String.format("%s/full/280,/0/native.jpg", service.getIdentifier()));
     } else {
-      thumb = new ImageContent(String.format("%s/full/280,/0/default.jpg", service.getIdentifier()));
+      thumb =
+          new ImageContent(String.format("%s/full/280,/0/default.jpg", service.getIdentifier()));
     }
     assertThat(thumb).isNotNull();
     assertThat(thumb.getIdentifier().toString()).contains("native.jpg");
@@ -75,13 +77,11 @@ public class ExternalTest {
     ImageService info = (ImageService) service;
     assertThat(info.getWidth()).isEqualTo(648);
     assertThat(info.getHeight()).isEqualTo(1024);
-    assertThat(info.getProfiles().get(0).getIdentifier().toString()).isEqualTo(
-      "http://iiif.io/api/image/2/level0.json");
-    assertThat(info.getSizes()).containsExactly(
-      new Size(648, 1024),
-      new Size(253, 400),
-      new Size(127, 200),
-      new Size(63, 100));
+    assertThat(info.getProfiles().get(0).getIdentifier().toString())
+        .isEqualTo("http://iiif.io/api/image/2/level0.json");
+    assertThat(info.getSizes())
+        .containsExactly(
+            new Size(648, 1024), new Size(253, 400), new Size(127, 200), new Size(63, 100));
     assertThat(info.getProfiles().get(1)).isInstanceOf(ImageApiProfile.class);
     ImageApiProfile profile = (ImageApiProfile) info.getProfiles().get(1);
     assertThat(profile.getFormats()).containsExactlyInAnyOrder(ImageApiProfile.Format.JPG);
@@ -92,30 +92,35 @@ public class ExternalTest {
   @Test
   public void testGallicaPropValsWithNoLanguage() throws Exception {
     Manifest manifest = readFromResources("gallica_propvals_without_language.json", Manifest.class);
-    PropertyValue creator = manifest.getMetadata().stream()
-      .filter(me -> me.getLabelString().equals("Creator"))
-      .map(me -> me.getValue())
-      .findFirst()
-      .orElseThrow(() -> new Exception("Could not find 'Creator' in metadata"));
+    PropertyValue creator =
+        manifest.getMetadata().stream()
+            .filter(me -> me.getLabelString().equals("Creator"))
+            .map(me -> me.getValue())
+            .findFirst()
+            .orElseThrow(() -> new Exception("Could not find 'Creator' in metadata"));
     assertThat(creator.getValues()).hasSize(5);
     assertThat(creator.getLocalizations()).containsOnly(Locale.forLanguageTag(""));
-    assertThat(creator.getValues()).containsExactly(
-      "Vincentius Bellovacensis (1190?-1264). Auteur du texte",
-      "Jean de Vignay (1282?-13..). Traducteur",
-      "Maître de Papeleu. Enlumineur",
-      "Maître de Cambrai. Enlumineur",
-      "Mahiet. Enlumineur");
+    assertThat(creator.getValues())
+        .containsExactly(
+            "Vincentius Bellovacensis (1190?-1264). Auteur du texte",
+            "Jean de Vignay (1282?-13..). Traducteur",
+            "Maître de Papeleu. Enlumineur",
+            "Maître de Cambrai. Enlumineur",
+            "Mahiet. Enlumineur");
   }
 
   @Test
   public void testTextgridWithResourceMotivation() throws Exception {
-    Manifest manifest = readFromResources("textgridlab.org-textgrid:3b09k.0-manifest.json", Manifest.class);
+    Manifest manifest =
+        readFromResources("textgridlab.org-textgrid:3b09k.0-manifest.json", Manifest.class);
     assertThat(manifest).isNotNull();
   }
 
   @Test
   public void testWellcomeWithEmptyLicenseString() throws Exception {
-    Manifest manifest = readFromResources("wellcomelibrary-b15404535-empty-license-string-manifest.json", Manifest.class);
+    Manifest manifest =
+        readFromResources(
+            "wellcomelibrary-b15404535-empty-license-string-manifest.json", Manifest.class);
     assertThat(manifest).isNotNull();
   }
 }

--- a/src/test/java/de/digitalcollections/iiif/model/JsonMappingTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/JsonMappingTest.java
@@ -1,9 +1,11 @@
 package de.digitalcollections.iiif.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
-import de.digitalcollections.iiif.model.JsonPathAssert;
 import de.digitalcollections.iiif.model.enums.ViewingHint;
 import de.digitalcollections.iiif.model.image.ImageApiProfile;
 import de.digitalcollections.iiif.model.image.ImageService;
@@ -20,12 +22,7 @@ import net.minidev.json.JSONArray;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-/**
- * Tests for writing out IIIF JSON.
- */
+/** Tests for writing out IIIF JSON. */
 public class JsonMappingTest {
 
   private ObjectMapper mapper;
@@ -82,20 +79,24 @@ public class JsonMappingTest {
 
     // Other stuff
     assertThatThrownBy(() -> canvas.addViewingHint(ViewingHint.INDIVIDUALS))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("Resources of type '%s' do not support the '%s' viewing hint.", "sc:Canvas", "individuals");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Resources of type '%s' do not support the '%s' viewing hint.",
+            "sc:Canvas", "individuals");
     canvas.addViewingHint(ViewingHint.NON_PAGED);
 
     // Licensing/Attribution
     canvas.addLicense("http://rightsstatements.org/vocab/NoC-NC/1.0/");
     canvas.addAttribution("Some fictional institution");
     canvas.addLogo("http://some.uri/logo.jpg");
-    canvas.addLogo(new ImageContent(new ImageService(
-      "http://some.uri/iiif/logo", ImageApiProfile.LEVEL_ONE)));
+    canvas.addLogo(
+        new ImageContent(new ImageService("http://some.uri/iiif/logo", ImageApiProfile.LEVEL_ONE)));
 
     String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(canvas);
     DocumentContext ctx = JsonPath.parse(json);
-    JsonPathAssert.assertThat(ctx).jsonPathAsString("['@context']").isEqualTo("http://iiif.io/api/presentation/2/context.json");
+    JsonPathAssert.assertThat(ctx)
+        .jsonPathAsString("['@context']")
+        .isEqualTo("http://iiif.io/api/presentation/2/context.json");
     JsonPathAssert.assertThat(ctx).jsonPathAsString("['@id']").isEqualTo("http://some.uri");
     JsonPathAssert.assertThat(ctx).jsonPathAsString("['@type']").isEqualTo("sc:Canvas");
     JsonPathAssert.assertThat(ctx).jsonPathAsString("label").isEqualTo("A label");
@@ -104,8 +105,10 @@ public class JsonMappingTest {
     JsonPathAssert.assertThat(ctx).jsonPathAsString("images[0].on").isEqualTo("http://some.uri");
 
     // Only the top-level object should have a IIIF Presentation API context
-    assertThat(((JSONArray) ctx.read("..['@context']")).stream()
-      .filter(c -> c.equals("http://iiif.io/api/presentation/2/context.json"))).hasSize(1);
+    assertThat(
+            ((JSONArray) ctx.read("..['@context']"))
+                .stream().filter(c -> c.equals("http://iiif.io/api/presentation/2/context.json")))
+        .hasSize(1);
 
     Canvas parsedCanvas = mapper.readValue(json, Canvas.class);
     assertThat(parsedCanvas).isEqualToComparingFieldByFieldRecursively(canvas);
@@ -119,7 +122,8 @@ public class JsonMappingTest {
     String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(manifest);
     DocumentContext ctx = JsonPath.parse(json);
     JsonPathAssert.assertThat(ctx).jsonPathAsString("navDate").isEqualTo("1970-01-01T00:00:00Z");
-    assertThat(mapper.readValue(json, Manifest.class).getNavDate()).isEqualTo(manifest.getNavDate());
+    assertThat(mapper.readValue(json, Manifest.class).getNavDate())
+        .isEqualTo(manifest.getNavDate());
 
     Collection coll = new Collection("http://some.uri", "A label for the Collection");
     coll.setNavDate(navDate);
@@ -139,5 +143,4 @@ public class JsonMappingTest {
     assertThat(parsed.getLabel().getValues()).containsExactly("Key");
     assertThat(parsed.getValue()).isNull();
   }
-
 }

--- a/src/test/java/de/digitalcollections/iiif/model/JsonPathAssert.java
+++ b/src/test/java/de/digitalcollections/iiif/model/JsonPathAssert.java
@@ -1,15 +1,16 @@
 /**
- * The following class was taken from https://github.com/revinate/assertj-json, which is licensed under MIT.
- * Here we circumwent an assertj-core binary compatibility problem, see https://github.com/joel-costigliola/assertj-core/issues/1317.
- * Latest assertj-json version was compiled with assertj-core in version 3.8.0, that is not compatible with >= 3.11.1.
+ * The following class was taken from https://github.com/revinate/assertj-json, which is licensed
+ * under MIT. Here we circumwent an assertj-core binary compatibility problem, see
+ * https://github.com/joel-costigliola/assertj-core/issues/1317. Latest assertj-json version was
+ * compiled with assertj-core in version 3.8.0, that is not compatible with >= 3.11.1.
  */
 package de.digitalcollections.iiif.model;
+
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.TypeRef;
-import org.assertj.core.api.*;
-
 import java.math.BigDecimal;
 import java.util.List;
+import org.assertj.core.api.*;
 
 /**
  * Assertions for {@link DocumentContext}.
@@ -47,18 +48,19 @@ public class JsonPathAssert extends AbstractAssert<JsonPathAssert, DocumentConte
   }
 
   /**
-   * Extracts a JSON array using a JsonPath expression and wrap it in a {@link ListAssert}. This method requires
-   * the JsonPath to be <a href="https://github.com/jayway/JsonPath#jsonprovider-spi">configured with Jackson or
-   * Gson</a>.
+   * Extracts a JSON array using a JsonPath expression and wrap it in a {@link ListAssert}. This
+   * method requires the JsonPath to be <a
+   * href="https://github.com/jayway/JsonPath#jsonprovider-spi">configured with Jackson or Gson</a>.
    *
    * @param path JsonPath to extract the array
    * @param type The type to cast the content of the array, i.e.: {@link String}, {@link Integer}
    * @param <T> The generic type of the type field
    * @return an instance of {@link ListAssert}
    */
-  public <T> AbstractListAssert<?, ? extends List<? extends T>, T, ? extends AbstractAssert<?, T>> jsonPathAsListOf(String path, Class<T> type) {
-    return Assertions.assertThat(actual.read(path, new TypeRef<List<T>>() {
-    }));
+  public <T>
+      AbstractListAssert<?, ? extends List<? extends T>, T, ? extends AbstractAssert<?, T>>
+          jsonPathAsListOf(String path, Class<T> type) {
+    return Assertions.assertThat(actual.read(path, new TypeRef<List<T>>() {}));
   }
 
   /**
@@ -82,8 +84,8 @@ public class JsonPathAssert extends AbstractAssert<JsonPathAssert, DocumentConte
   }
 
   /**
-   * Extracts a any JSON type using a JsonPath expression and wrap it in an {@link ObjectAssert}. Use this method
-   * to check for nulls or to do type checks.
+   * Extracts a any JSON type using a JsonPath expression and wrap it in an {@link ObjectAssert}.
+   * Use this method to check for nulls or to do type checks.
    *
    * @param path JsonPath to extract the type
    * @return an instance of {@link ObjectAssert}

--- a/src/test/java/de/digitalcollections/iiif/model/ParsingTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/ParsingTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.io.Resources;
 import de.digitalcollections.iiif.model.image.ImageApiProfile;
 import de.digitalcollections.iiif.model.image.ImageApiProfile.Format;
@@ -15,12 +17,10 @@ import java.util.Locale;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
  * Tests for parsing IIIF JSON.
  *
- * Covers some things that are not well tested in the examples from the specifications.
+ * <p>Covers some things that are not well tested in the examples from the specifications.
  */
 public class ParsingTest {
 
@@ -32,8 +32,7 @@ public class ParsingTest {
   }
 
   private <T> T readFromResources(String filename, Class<T> clz) throws IOException {
-    return mapper.readValue(
-      Resources.getResource(filename), clz);
+    return mapper.readValue(Resources.getResource(filename), clz);
   }
 
   @Test
@@ -65,11 +64,13 @@ public class ParsingTest {
   public void testV10Manifest() throws Exception {
     Manifest manifest = readFromResources("presiV10Manifest.json", Manifest.class);
     assertThat(manifest.getLabelString()).isEqualTo("Book 1");
-    assertThat(manifest.getMetadata().stream()
-      .filter(e -> e.getLabel().getFirstValue().equals("Published"))
-      .findFirst()
-      .map(e -> e.getValue().getLocalizations())
-      .get()).containsExactlyInAnyOrder(Locale.ENGLISH, Locale.FRENCH);
+    assertThat(
+            manifest.getMetadata().stream()
+                .filter(e -> e.getLabel().getFirstValue().equals("Published"))
+                .findFirst()
+                .map(e -> e.getValue().getLocalizations())
+                .get())
+        .containsExactlyInAnyOrder(Locale.ENGLISH, Locale.FRENCH);
     assertThat(manifest.getDefaultSequence().getCanvases()).hasSize(3);
     assertThat(manifest.getRanges()).hasSize(1);
     assertThat(manifest.getRanges().get(0).getCanvases()).hasSize(3);
@@ -77,14 +78,21 @@ public class ParsingTest {
     assertThat(canvas.getImages().get(0).getResource()).isInstanceOf(ImageContent.class);
     ImageContent imgRes = (ImageContent) canvas.getImages().get(0).getResource();
     assertThat(imgRes.getServices().get(0)).isInstanceOf(ImageService.class);
-    ImageService service = (ImageService) manifest.getDefaultSequence().getCanvases().get(1).getImages()
-      .get(0).getResource().getServices().get(0);
+    ImageService service =
+        (ImageService)
+            manifest
+                .getDefaultSequence()
+                .getCanvases()
+                .get(1)
+                .getImages()
+                .get(0)
+                .getResource()
+                .getServices()
+                .get(0);
     assertThat(service.getWidth()).isEqualTo(6000);
     assertThat(service.getHeight()).isEqualTo(8000);
-    assertThat(service.getSizes()).containsExactly(
-      new Size(6000, 8000),
-      new Size(3000, 4000),
-      new Size(1500, 2000));
+    assertThat(service.getSizes())
+        .containsExactly(new Size(6000, 8000), new Size(3000, 4000), new Size(1500, 2000));
     assertThat(service.getTiles()).hasSize(1);
     assertThat(service.getTiles().get(0).getScaleFactors()).containsExactly(1, 2, 4);
     assertThat(service.getTiles().get(0).getWidth()).isEqualTo(1024);
@@ -97,14 +105,17 @@ public class ParsingTest {
     assertThat(manifest.getLabelString()).isEqualTo("A Lady and Her Two Children (B1981.25.278)");
     assertThat(manifest.getDefaultSequence().getCanvases()).hasSize(7);
     Canvas canvas = manifest.getDefaultSequence().getCanvases().get(0);
-    assertThat(canvas.getImages().get(0).getResource().getServices().get(0)).isInstanceOf(ImageService.class);
+    assertThat(canvas.getImages().get(0).getResource().getServices().get(0))
+        .isInstanceOf(ImageService.class);
     canvas = manifest.getDefaultSequence().getCanvases().get(6);
     assertThat(canvas.getImages().get(0).getResource()).isInstanceOf(ImageContent.class);
     ImageContent imgContent = (ImageContent) canvas.getImages().get(0).getResource();
     assertThat(imgContent.getAlternatives()).isNotEmpty();
     assertThat(imgContent.getServices().get(0)).isInstanceOf(ImageService.class);
-    assertThat(imgContent.getServices().get(0).getProfiles()).containsExactly(
-      ImageApiProfile.fromUrl("http://library.stanford.edu/iiif/image-api/1.1/conformance.html#level1"));
+    assertThat(imgContent.getServices().get(0).getProfiles())
+        .containsExactly(
+            ImageApiProfile.fromUrl(
+                "http://library.stanford.edu/iiif/image-api/1.1/conformance.html#level1"));
     assertThat(imgContent.getAlternatives()).hasSize(2);
     assertThat(imgContent.getAlternatives()).allMatch(ImageContent.class::isInstance);
   }
@@ -119,17 +130,15 @@ public class ParsingTest {
     ImageService info = (ImageService) service;
     assertThat(info.getWidth()).isEqualTo(6000);
     assertThat(info.getHeight()).isEqualTo(4000);
-    assertThat(info.getProfiles().get(0).getIdentifier().toString()).isEqualTo(
-      "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level0");
-    assertThat(info.getSizes()).containsExactly(
-      new Size(6000, 4000),
-      new Size(3000, 2000),
-      new Size(1500, 1000));
+    assertThat(info.getProfiles().get(0).getIdentifier().toString())
+        .isEqualTo("http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level0");
+    assertThat(info.getSizes())
+        .containsExactly(new Size(6000, 4000), new Size(3000, 2000), new Size(1500, 1000));
     assertThat(info.getTiles()).hasSize(1);
     assertThat(info.getTiles().get(0).getScaleFactors()).containsExactly(1, 2, 4);
     assertThat(info.getTiles().get(0))
-      .hasFieldOrPropertyWithValue("width", 1024)
-      .hasFieldOrPropertyWithValue("height", 1024);
+        .hasFieldOrPropertyWithValue("width", 1024)
+        .hasFieldOrPropertyWithValue("height", 1024);
     assertThat(info.getProfiles().get(1)).isInstanceOf(ImageApiProfile.class);
     ImageApiProfile profile = (ImageApiProfile) info.getProfiles().get(1);
     assertThat(profile.getFormats()).containsExactlyInAnyOrder(Format.JPG, Format.PNG);
@@ -139,21 +148,21 @@ public class ParsingTest {
   @Test
   public void testParseImageApiFeatures() throws Exception {
     ImageApiProfile profile = readFromResources("featureProfile.json", ImageApiProfile.class);
-    assertThat(profile.getFeatures()).containsExactlyInAnyOrder(
-      ImageApiProfile.Feature.BASE_URI_REDIRECT,
-      ImageApiProfile.Feature.CORS,
-      ImageApiProfile.Feature.JSONLD_MEDIA_TYPE,
-      ImageApiProfile.Feature.MIRRORING,
-      ImageApiProfile.Feature.PROFILE_LINK_HEADER,
-      ImageApiProfile.Feature.REGION_BY_PX,
-      ImageApiProfile.Feature.REGION_SQUARE,
-      ImageApiProfile.Feature.REGION_BY_PCT,
-      ImageApiProfile.Feature.ROTATION_BY_90S,
-      ImageApiProfile.Feature.SIZE_BY_CONFINED_WH,
-      ImageApiProfile.Feature.SIZE_BY_H,
-      ImageApiProfile.Feature.SIZE_BY_PCT,
-      ImageApiProfile.Feature.SIZE_BY_W,
-      ImageApiProfile.Feature.SIZE_BY_WH
-    );
+    assertThat(profile.getFeatures())
+        .containsExactlyInAnyOrder(
+            ImageApiProfile.Feature.BASE_URI_REDIRECT,
+            ImageApiProfile.Feature.CORS,
+            ImageApiProfile.Feature.JSONLD_MEDIA_TYPE,
+            ImageApiProfile.Feature.MIRRORING,
+            ImageApiProfile.Feature.PROFILE_LINK_HEADER,
+            ImageApiProfile.Feature.REGION_BY_PX,
+            ImageApiProfile.Feature.REGION_SQUARE,
+            ImageApiProfile.Feature.REGION_BY_PCT,
+            ImageApiProfile.Feature.ROTATION_BY_90S,
+            ImageApiProfile.Feature.SIZE_BY_CONFINED_WH,
+            ImageApiProfile.Feature.SIZE_BY_H,
+            ImageApiProfile.Feature.SIZE_BY_PCT,
+            ImageApiProfile.Feature.SIZE_BY_W,
+            ImageApiProfile.Feature.SIZE_BY_WH);
   }
 }

--- a/src/test/java/de/digitalcollections/iiif/model/PropertyValueTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/PropertyValueTest.java
@@ -1,10 +1,10 @@
 package de.digitalcollections.iiif.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import de.digitalcollections.iiif.model.jackson.IiifObjectMapper;
 import java.util.Locale;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class PropertyValueTest {
 
@@ -35,11 +35,12 @@ public class PropertyValueTest {
     PropertyValue propVal = new PropertyValue();
     propVal.addValue(Locale.ENGLISH, "one", "two");
     String json = mapper.writeValueAsString(propVal);
-    assertThat(json).isEqualTo(
-      "[{'@language':'en','@value':'one'},{'@language':'en','@value':'two'}]".replace("'", "\""));
+    assertThat(json)
+        .isEqualTo(
+            "[{'@language':'en','@value':'one'},{'@language':'en','@value':'two'}]"
+                .replace("'", "\""));
     PropertyValue deserialized = mapper.readValue(json, PropertyValue.class);
     assertThat(deserialized.getLocalizations()).containsOnly(Locale.ENGLISH);
     assertThat(deserialized.getValues(Locale.ENGLISH)).containsExactly("one", "two");
   }
-
 }

--- a/src/test/java/de/digitalcollections/iiif/model/annex/SpecExamplesDeserializationTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/annex/SpecExamplesDeserializationTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.model.annex;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import de.digitalcollections.iiif.model.GenericService;
@@ -19,8 +21,6 @@ import org.geojson.Point;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class SpecExamplesDeserializationTest {
 
   private ObjectMapper mapper;
@@ -31,38 +31,35 @@ public class SpecExamplesDeserializationTest {
   }
 
   private <T> T readFromResources(String filename, Class<T> clz) throws IOException {
-    return mapper.readValue(
-      Resources.getResource("spec/annex/" + filename), clz);
+    return mapper.readValue(Resources.getResource("spec/annex/" + filename), clz);
   }
 
   @Test
   public void testAdditionalInfo() throws Exception {
     ImageService service = readFromResources("additionalInfo.json", ImageService.class);
     assertThat(service.getIdentifier().toString())
-      .isEqualTo("http://www.example.org/image-service/abcd1234");
+        .isEqualTo("http://www.example.org/image-service/abcd1234");
     assertThat(service)
-      .hasFieldOrPropertyWithValue("width", 6000)
-      .hasFieldOrPropertyWithValue("height", 4000);
-    assertThat(service.getSizes()).containsExactly(
-      new Size(150, 100),
-      new Size(600, 400),
-      new Size(3000, 2000));
+        .hasFieldOrPropertyWithValue("width", 6000)
+        .hasFieldOrPropertyWithValue("height", 4000);
+    assertThat(service.getSizes())
+        .containsExactly(new Size(150, 100), new Size(600, 400), new Size(3000, 2000));
     assertThat(service.getTiles().get(0))
-      .hasFieldOrPropertyWithValue("width", 512)
-      .hasFieldOrPropertyWithValue("scaleFactors", Arrays.asList(1, 2, 4, 8, 16));
+        .hasFieldOrPropertyWithValue("width", 512)
+        .hasFieldOrPropertyWithValue("scaleFactors", Arrays.asList(1, 2, 4, 8, 16));
 
     assertThat(service.getProfiles()).hasSize(2);
-    assertThat(service.getProfiles().get(0))
-      .isEqualTo(ImageApiProfile.LEVEL_TWO);
-    assertThat(service.getProfiles().get(1))
-      .isInstanceOf(ImageApiProfile.class);
+    assertThat(service.getProfiles().get(0)).isEqualTo(ImageApiProfile.LEVEL_TWO);
+    assertThat(service.getProfiles().get(1)).isInstanceOf(ImageApiProfile.class);
     ImageApiProfile complexProfile = (ImageApiProfile) service.getProfiles().get(1);
     assertThat(complexProfile.getFormats()).containsExactlyInAnyOrder(Format.GIF, Format.PDF);
-    assertThat(complexProfile.getQualities()).containsExactlyInAnyOrder(Quality.COLOR, Quality.GRAY);
-    assertThat(complexProfile.getFeatures()).containsExactlyInAnyOrder(
-      Feature.CANONICAL_LINK_HEADER,
-      Feature.ROTATION_ARBITRARY,
-      new Feature("http://example.com/feature"));
+    assertThat(complexProfile.getQualities())
+        .containsExactlyInAnyOrder(Quality.COLOR, Quality.GRAY);
+    assertThat(complexProfile.getFeatures())
+        .containsExactlyInAnyOrder(
+            Feature.CANONICAL_LINK_HEADER,
+            Feature.ROTATION_ARBITRARY,
+            new Feature("http://example.com/feature"));
   }
 
   @Test
@@ -71,51 +68,49 @@ public class SpecExamplesDeserializationTest {
     assertThat(service.getAttributionString()).isEqualTo("Provided by Example Organization");
     assertThat(service.getLogos()).hasSize(1);
     assertThat(service.getLogos().get(0).getIdentifier().toString())
-      .isEqualTo("http://example.org/image-service/logo/full/full/0/default.png");
-    assertThat(service.getLogos().get(0).getServices().get(0))
-      .isInstanceOf(ImageService.class);
+        .isEqualTo("http://example.org/image-service/logo/full/full/0/default.png");
+    assertThat(service.getLogos().get(0).getServices().get(0)).isInstanceOf(ImageService.class);
     ImageService imageService = (ImageService) service.getLogos().get(0).getServices().get(0);
     assertThat(imageService.getIdentifier().toString())
-      .isEqualTo("http://example.org/image-service/logo");
-    assertThat(imageService.getProfiles())
-      .containsExactly(ImageApiProfile.LEVEL_TWO);
+        .isEqualTo("http://example.org/image-service/logo");
+    assertThat(imageService.getProfiles()).containsExactly(ImageApiProfile.LEVEL_TWO);
   }
 
   @Test
   public void testGenericService() throws Exception {
     GenericService service = readFromResources("genericService.json", GenericService.class);
     assertThat(service.getContext().toString())
-      .isEqualTo("http://example.org/ns/jsonld/context.json");
+        .isEqualTo("http://example.org/ns/jsonld/context.json");
     assertThat(service.getIdentifier().toString())
-      .isEqualTo("http://example.org/service/example.json");
+        .isEqualTo("http://example.org/service/example.json");
     assertThat(service.getProfiles())
-      .containsExactly(new Profile(URI.create("http://example.org/docs/example-service.html")));
+        .containsExactly(new Profile(URI.create("http://example.org/docs/example-service.html")));
     assertThat(service.getLabelString()).isEqualTo("Example Service");
   }
 
   @Test
   public void testGeoJsonEmbedded() throws Exception {
     GeoService service = readFromResources("geoJsonEmbedded.json", GeoService.class);
-    assertThat(service.getFeature().getProperties())
-      .containsEntry("name", "Paris");
-    assertThat(service.getFeature().getGeometry())
-      .isInstanceOf(Point.class);
+    assertThat(service.getFeature().getProperties()).containsEntry("name", "Paris");
+    assertThat(service.getFeature().getGeometry()).isInstanceOf(Point.class);
     assertThat(((Point) service.getFeature().getGeometry()).getCoordinates())
-      .hasFieldOrPropertyWithValue("longitude", 48.8567)
-      .hasFieldOrPropertyWithValue("latitude", 2.3508);
+        .hasFieldOrPropertyWithValue("longitude", 48.8567)
+        .hasFieldOrPropertyWithValue("latitude", 2.3508);
   }
 
   @Test
   public void testGeoJsonExternal() throws Exception {
     GeoService service = readFromResources("geoJsonExternal.json", GeoService.class);
-    assertThat(service.getIdentifier().toString()).isEqualTo("http://www.example.org/geojson/paris.json");
+    assertThat(service.getIdentifier().toString())
+        .isEqualTo("http://www.example.org/geojson/paris.json");
   }
 
   @Test
   public void testPhysicalDimensionsService() throws Exception {
-    PhysicalDimensionsService service = readFromResources("physicalDimensions.json", PhysicalDimensionsService.class);
+    PhysicalDimensionsService service =
+        readFromResources("physicalDimensions.json", PhysicalDimensionsService.class);
     assertThat(service)
-      .hasFieldOrPropertyWithValue("physicalScale", 0.0025)
-      .hasFieldOrPropertyWithValue("physicalUnits", Unit.INCHES);
+        .hasFieldOrPropertyWithValue("physicalScale", 0.0025)
+        .hasFieldOrPropertyWithValue("physicalUnits", Unit.INCHES);
   }
 }

--- a/src/test/java/de/digitalcollections/iiif/model/annex/SpecExamplesSerializationTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/annex/SpecExamplesSerializationTest.java
@@ -35,10 +35,11 @@ public class SpecExamplesSerializationTest {
 
   private String readFromResources(String filename) throws IOException {
     return Resources.toString(
-      Resources.getResource("spec/annex/" + filename), Charset.defaultCharset());
+        Resources.getResource("spec/annex/" + filename), Charset.defaultCharset());
   }
 
-  private void assertSerializationEqualsSpec(Object obj, String specFilename) throws IOException, JSONException {
+  private void assertSerializationEqualsSpec(Object obj, String specFilename)
+      throws IOException, JSONException {
     String specJson = readFromResources(specFilename);
     String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
     JSONAssert.assertEquals(specJson, json, true);
@@ -46,21 +47,22 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testAdditionalInfo() throws Exception {
-    ImageService service = new ImageService("http://www.example.org/image-service/abcd1234",
-      ImageApiProfile.LEVEL_TWO);
+    ImageService service =
+        new ImageService(
+            "http://www.example.org/image-service/abcd1234", ImageApiProfile.LEVEL_TWO);
 
     ImageApiProfile profile = new ImageApiProfile();
     profile.addFormat(Format.GIF, Format.PDF);
     profile.addQuality(Quality.COLOR, Quality.GRAY);
-    profile.addFeature(Feature.CANONICAL_LINK_HEADER, Feature.ROTATION_ARBITRARY,
-      new Feature("http://example.com/feature"));
+    profile.addFeature(
+        Feature.CANONICAL_LINK_HEADER,
+        Feature.ROTATION_ARBITRARY,
+        new Feature("http://example.com/feature"));
     service.addProfile(profile);
 
     service.setWidth(6000);
     service.setHeight(4000);
-    service.addSize(new Size(150, 100),
-      new Size(600, 400),
-      new Size(3000, 2000));
+    service.addSize(new Size(150, 100), new Size(600, 400), new Size(3000, 2000));
 
     TileInfo tileInfo = new TileInfo(512);
     tileInfo.addScaleFactor(1, 2, 4, 8, 16);
@@ -73,10 +75,14 @@ public class SpecExamplesSerializationTest {
   public void testEmbeddedService() throws Exception {
     // FIXME: We had to modify the spec example by adding a @context to the logo service
     //        We should instead find a way to avoid duplicate @contexts in the tree
-    ImageService service = new ImageService("http://www.example.org/image-service/baseImage", ImageApiProfile.LEVEL_TWO);
+    ImageService service =
+        new ImageService(
+            "http://www.example.org/image-service/baseImage", ImageApiProfile.LEVEL_TWO);
     service.addAttribution("Provided by Example Organization");
-    ImageContent logo = new ImageContent("http://example.org/image-service/logo/full/full/0/default.png");
-    logo.addService(new ImageService("http://example.org/image-service/logo", ImageApiProfile.LEVEL_TWO));
+    ImageContent logo =
+        new ImageContent("http://example.org/image-service/logo/full/full/0/default.png");
+    logo.addService(
+        new ImageService("http://example.org/image-service/logo", ImageApiProfile.LEVEL_TWO));
     logo.setFormat((MimeType) null);
     service.addLogo(logo);
     assertSerializationEqualsSpec(service, "embeddedService.json");
@@ -84,9 +90,11 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testGenericService() throws Exception {
-    GenericService service = new GenericService("http://example.org/ns/jsonld/context.json",
-      "http://example.org/service/example.json",
-      "http://example.org/docs/example-service.html");
+    GenericService service =
+        new GenericService(
+            "http://example.org/ns/jsonld/context.json",
+            "http://example.org/service/example.json",
+            "http://example.org/docs/example-service.html");
     service.setLabel(new PropertyValue("Example Service"));
     assertSerializationEqualsSpec(service, "genericService.json");
   }

--- a/src/test/java/de/digitalcollections/iiif/model/auth/SpecExamplesDeserializationTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/auth/SpecExamplesDeserializationTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.model.auth;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import de.digitalcollections.iiif.model.auth.errors.AccessTokenError;
@@ -9,8 +11,6 @@ import de.digitalcollections.iiif.model.jackson.IiifObjectMapper;
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class SpecExamplesDeserializationTest {
 
@@ -22,8 +22,7 @@ public class SpecExamplesDeserializationTest {
   }
 
   private <T> T readFromResources(String filename, Class<T> clz) throws IOException {
-    return mapper.readValue(
-      Resources.getResource("spec/auth/" + filename), clz);
+    return mapper.readValue(Resources.getResource("spec/auth/" + filename), clz);
   }
 
   @Test
@@ -33,11 +32,11 @@ public class SpecExamplesDeserializationTest {
     assertThat(service.getLabelString()).isEqualTo("Login to Example Institution");
     assertThat(service.getHeaderString()).isEqualTo("Please Log In");
     assertThat(service.getFailureDescriptionString())
-      .isEqualTo("<a href=\"http://example.org/policy\">Access Policy</a>");
+        .isEqualTo("<a href=\"http://example.org/policy\">Access Policy</a>");
     assertThat(service.getServices()).hasSize(1);
     assertThat(service.getServices().get(0)).isInstanceOf(AccessTokenService.class);
     assertThat(((AccessTokenService) service.getServices().get(0)).getIdentifier().toString())
-      .isEqualTo("https://authentication.example.org/token");
+        .isEqualTo("https://authentication.example.org/token");
   }
 
   @Test
@@ -48,13 +47,15 @@ public class SpecExamplesDeserializationTest {
 
   @Test
   public void testCookieServiceWithClickthroughPattern() throws IOException {
-    AccessCookieService service = readFromResources("cookieClickthrough.json", AccessCookieService.class);
+    AccessCookieService service =
+        readFromResources("cookieClickthrough.json", AccessCookieService.class);
     assertThat(service.getAuthPattern()).isEqualTo(AuthPattern.CLICKTHROUGH);
   }
 
   @Test
   public void testCookieServiceWithExternalPattern() throws IOException {
-    AccessCookieService service = readFromResources("cookieExternal.json", AccessCookieService.class);
+    AccessCookieService service =
+        readFromResources("cookieExternal.json", AccessCookieService.class);
     assertThat(service.getAuthPattern()).isEqualTo(AuthPattern.EXTERNAL);
   }
 
@@ -63,7 +64,7 @@ public class SpecExamplesDeserializationTest {
     AccessTokenError err = readFromResources("errorCondition.json", AccessTokenError.class);
     assertThat(err).isInstanceOf(InvalidCredentials.class);
     assertThat(err.getDescription())
-      .isEqualTo("The request had credentials that are not valid for the service.");
+        .isEqualTo("The request had credentials that are not valid for the service.");
   }
 
   @Test
@@ -80,7 +81,8 @@ public class SpecExamplesDeserializationTest {
 
   @Test
   public void testLoginWithLogout() throws IOException {
-    AccessCookieService authService = readFromResources("loginWithLogout.json", AccessCookieService.class);
+    AccessCookieService authService =
+        readFromResources("loginWithLogout.json", AccessCookieService.class);
     assertThat(authService.getServices()).hasSize(2);
     assertThat(authService.getServices().get(0)).isInstanceOf(AccessTokenService.class);
     assertThat(authService.getServices().get(1)).isInstanceOf(LogoutService.class);

--- a/src/test/java/de/digitalcollections/iiif/model/auth/SpecExamplesSerializationTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/auth/SpecExamplesSerializationTest.java
@@ -31,10 +31,11 @@ public class SpecExamplesSerializationTest {
 
   private String readFromResources(String filename) throws IOException {
     return Resources.toString(
-      Resources.getResource("spec/auth/" + filename), Charset.defaultCharset());
+        Resources.getResource("spec/auth/" + filename), Charset.defaultCharset());
   }
 
-  private void assertSerializationEqualsSpec(Object obj, String specFilename) throws IOException, JSONException {
+  private void assertSerializationEqualsSpec(Object obj, String specFilename)
+      throws IOException, JSONException {
     String specJson = readFromResources(specFilename);
     String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
     JSONAssert.assertEquals(specJson, json, true);
@@ -42,8 +43,9 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testClickthroughPattern() throws IOException, JSONException {
-    AccessCookieService service = new AccessCookieService("https://authentication.example.org/clickthrough",
-      AuthPattern.CLICKTHROUGH);
+    AccessCookieService service =
+        new AccessCookieService(
+            "https://authentication.example.org/clickthrough", AuthPattern.CLICKTHROUGH);
     service.setLabel("Terms of Use for Example Institution");
     service.setHeader("Restricted Material with Terms of Use");
     service.setDescription("<span>... terms of use ... </span>");
@@ -66,7 +68,9 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testKioskPattern() throws IOException, JSONException {
-    AccessCookieService service = new AccessCookieService("https://authentication.example.org/cookiebaker", AuthPattern.KIOSK);
+    AccessCookieService service =
+        new AccessCookieService(
+            "https://authentication.example.org/cookiebaker", AuthPattern.KIOSK);
     service.setLabel("Internal cookie granting service");
     service.setFailureHeader("Ooops!");
     service.setFailureDescription("Call Bob at ext. 1234 to reboot the cookie server");
@@ -76,10 +80,12 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testLoginPattern() throws IOException, JSONException {
-    AccessCookieService service = new AccessCookieService("https://authentication.example.org/login", AuthPattern.LOGIN);
+    AccessCookieService service =
+        new AccessCookieService("https://authentication.example.org/login", AuthPattern.LOGIN);
     service.setLabel("Login to Example Institution");
     service.setHeader("Please Log In");
-    service.setDescription("Example Institution requires that you log in with your example account to view this content.");
+    service.setDescription(
+        "Example Institution requires that you log in with your example account to view this content.");
     service.setConfirmLabel("Login");
     service.setFailureHeader("Authentication Failed");
     service.setFailureDescription("<a href=\"http://example.org/policy\">Access Policy</a>");
@@ -89,13 +95,15 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testErrorCondition() throws IOException, JSONException {
-    InvalidCredentials err = new InvalidCredentials("The request had credentials that are not valid for the service.");
+    InvalidCredentials err =
+        new InvalidCredentials("The request had credentials that are not valid for the service.");
     assertSerializationEqualsSpec(err, "errorCondition.json");
   }
 
   @Test
   public void testImageInfoWithAuth() throws IOException, JSONException {
-    ImageService service = new ImageService("https://www.example.org/images/image1", ImageApiProfile.LEVEL_TWO);
+    ImageService service =
+        new ImageService("https://www.example.org/images/image1", ImageApiProfile.LEVEL_TWO);
     service.setWidth(600);
     service.setHeight(400);
     service.addSize(new Size(150, 100), new Size(600, 400));
@@ -105,11 +113,12 @@ public class SpecExamplesSerializationTest {
     profile.addFeature(Feature.CANONICAL_LINK_HEADER, Feature.ROTATION_ARBITRARY);
     service.addProfile(profile);
 
-    AccessCookieService authService = new AccessCookieService("https://authentication.example.org/login", AuthPattern.LOGIN);
+    AccessCookieService authService =
+        new AccessCookieService("https://authentication.example.org/login", AuthPattern.LOGIN);
     authService.setLabel("Login to Example Institution");
     authService.addService(
-      new AccessTokenService("https://authentication.example.org/token"),
-      new LogoutService("https://authentication.example.org/logout"));
+        new AccessTokenService("https://authentication.example.org/token"),
+        new LogoutService("https://authentication.example.org/logout"));
     ((LogoutService) authService.getServices().get(1)).setLabel("Logout from Example Institution");
     service.addService(authService);
 
@@ -118,11 +127,12 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testLoginWithLogout() throws IOException, JSONException {
-    AccessCookieService authService = new AccessCookieService("https://authentication.example.org/login", AuthPattern.LOGIN);
+    AccessCookieService authService =
+        new AccessCookieService("https://authentication.example.org/login", AuthPattern.LOGIN);
     authService.setLabel("Login to Example Institution");
     authService.addService(
-      new AccessTokenService("https://authentication.example.org/token"),
-      new LogoutService("https://authentication.example.org/logout"));
+        new AccessTokenService("https://authentication.example.org/token"),
+        new LogoutService("https://authentication.example.org/logout"));
     ((LogoutService) authService.getServices().get(1)).setLabel("Logout from Example Institution");
     assertSerializationEqualsSpec(authService, "loginWithLogout.json");
   }

--- a/src/test/java/de/digitalcollections/iiif/model/image/ProfileTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/image/ProfileTest.java
@@ -1,5 +1,8 @@
 package de.digitalcollections.iiif.model.image;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
@@ -9,9 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
 public class ProfileTest {
 
   @Test
@@ -19,9 +19,10 @@ public class ProfileTest {
     List<Profile> profiles = new ArrayList<>();
     profiles.add(ImageApiProfile.LEVEL_ONE);
     ImageApiProfile extraProfile = new ImageApiProfile();
-    extraProfile.addFeature(ImageApiProfile.Feature.REGION_BY_PCT,
-      ImageApiProfile.Feature.SIZE_BY_CONFINED_WH,
-      ImageApiProfile.Feature.SIZE_ABOVE_FULL);
+    extraProfile.addFeature(
+        ImageApiProfile.Feature.REGION_BY_PCT,
+        ImageApiProfile.Feature.SIZE_BY_CONFINED_WH,
+        ImageApiProfile.Feature.SIZE_ABOVE_FULL);
     extraProfile.addFormat(ImageApiProfile.Format.JP2);
     extraProfile.setMaxWidth(2048);
     extraProfile.setMaxArea((long) 500000);
@@ -31,19 +32,20 @@ public class ProfileTest {
     profiles.add(extraProfile);
     profiles.add(limitProfile);
     ImageApiProfile merged = ImageApiProfile.merge(profiles);
-    assertThat(merged.getFeatures()).containsExactlyInAnyOrder(
-      ImageApiProfile.Feature.REGION_BY_PX,
-      ImageApiProfile.Feature.SIZE_BY_W,
-      ImageApiProfile.Feature.SIZE_BY_H,
-      ImageApiProfile.Feature.SIZE_BY_PCT,
-      ImageApiProfile.Feature.BASE_URI_REDIRECT,
-      ImageApiProfile.Feature.CORS,
-      ImageApiProfile.Feature.JSONLD_MEDIA_TYPE,
-      ImageApiProfile.Feature.REGION_BY_PCT,
-      ImageApiProfile.Feature.SIZE_BY_CONFINED_WH,
-      ImageApiProfile.Feature.SIZE_ABOVE_FULL);
-    assertThat(merged.getFormats()).containsExactlyInAnyOrder(
-      ImageApiProfile.Format.JPG, ImageApiProfile.Format.JP2);
+    assertThat(merged.getFeatures())
+        .containsExactlyInAnyOrder(
+            ImageApiProfile.Feature.REGION_BY_PX,
+            ImageApiProfile.Feature.SIZE_BY_W,
+            ImageApiProfile.Feature.SIZE_BY_H,
+            ImageApiProfile.Feature.SIZE_BY_PCT,
+            ImageApiProfile.Feature.BASE_URI_REDIRECT,
+            ImageApiProfile.Feature.CORS,
+            ImageApiProfile.Feature.JSONLD_MEDIA_TYPE,
+            ImageApiProfile.Feature.REGION_BY_PCT,
+            ImageApiProfile.Feature.SIZE_BY_CONFINED_WH,
+            ImageApiProfile.Feature.SIZE_ABOVE_FULL);
+    assertThat(merged.getFormats())
+        .containsExactlyInAnyOrder(ImageApiProfile.Format.JPG, ImageApiProfile.Format.JP2);
     assertThat(merged.getMaxWidth()).isEqualTo(1024);
     assertThat(merged.getMaxArea()).isEqualTo(500000);
   }
@@ -52,12 +54,12 @@ public class ProfileTest {
   public void testCustomProfileSerialization() throws JsonProcessingException {
     ImageApiProfile profile = new ImageApiProfile();
     profile.addFeature(
-      ImageApiProfile.Feature.PROFILE_LINK_HEADER,
-      ImageApiProfile.Feature.CANONICAL_LINK_HEADER,
-      ImageApiProfile.Feature.REGION_SQUARE,
-      ImageApiProfile.Feature.ROTATION_BY_90S,
-      ImageApiProfile.Feature.MIRRORING,
-      ImageApiProfile.Feature.SIZE_ABOVE_FULL);
+        ImageApiProfile.Feature.PROFILE_LINK_HEADER,
+        ImageApiProfile.Feature.CANONICAL_LINK_HEADER,
+        ImageApiProfile.Feature.REGION_SQUARE,
+        ImageApiProfile.Feature.ROTATION_BY_90S,
+        ImageApiProfile.Feature.MIRRORING,
+        ImageApiProfile.Feature.SIZE_ABOVE_FULL);
     profile.addFormat(ImageApiProfile.Format.GIF);
 
     // Indicate to the client if we cannot deliver full resolution versions of the image
@@ -66,7 +68,7 @@ public class ProfileTest {
 
     IiifObjectMapper mapper = new IiifObjectMapper();
     String json = mapper.writeValueAsString(profile);
-    assertThatExceptionOfType(PathNotFoundException.class).isThrownBy(
-      () -> JsonPath.parse(json).read("$.qualities"));
+    assertThatExceptionOfType(PathNotFoundException.class)
+        .isThrownBy(() -> JsonPath.parse(json).read("$.qualities"));
   }
 }

--- a/src/test/java/de/digitalcollections/iiif/model/image/SelectorTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/image/SelectorTest.java
@@ -1,13 +1,13 @@
 package de.digitalcollections.iiif.model.image;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
 import java.net.URI;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class SelectorTest {
 
@@ -24,9 +24,12 @@ public class SelectorTest {
     assertThat(selector.toString()).isEqualTo("abcd1234/full/full/0/default.jpg");
 
     // With prefix
-    assertThat(ImageApiSelector.fromImageApiUri(
-      URI.create("https://example.com/some-prefix/another-prefix/id/full/full/0/default.jpg")).toString())
-      .isEqualTo("id/full/full/0/default.jpg");
+    assertThat(
+            ImageApiSelector.fromImageApiUri(
+                    URI.create(
+                        "https://example.com/some-prefix/another-prefix/id/full/full/0/default.jpg"))
+                .toString())
+        .isEqualTo("id/full/full/0/default.jpg");
   }
 
   @Test
@@ -35,12 +38,14 @@ public class SelectorTest {
     RegionRequest req = RegionRequest.fromString("full");
     assertThat(req).hasFieldOrPropertyWithValue("region", null);
     assertThat(req.toString()).isEqualTo("full");
-    assertThat(req.resolve(imageDims)).isEqualTo(new Rectangle(0, 0, imageDims.width, imageDims.height));
+    assertThat(req.resolve(imageDims))
+        .isEqualTo(new Rectangle(0, 0, imageDims.width, imageDims.height));
 
     req = RegionRequest.fromString("square");
     assertThat(req).hasFieldOrPropertyWithValue("square", true);
     assertThat(req.toString()).isEqualTo("square");
-    assertThat(req.resolve(imageDims)).isEqualTo(new Rectangle(0, 1771, imageDims.width, imageDims.width));
+    assertThat(req.resolve(imageDims))
+        .isEqualTo(new Rectangle(0, 1771, imageDims.width, imageDims.width));
 
     req = RegionRequest.fromString("125,15,120,140");
     assertThat(req).hasFieldOrPropertyWithValue("region", new Rectangle(125, 15, 120, 140));
@@ -48,17 +53,16 @@ public class SelectorTest {
     assertThat(req.resolve(imageDims)).isEqualTo(new Rectangle(125, 15, 120, 140));
 
     req = RegionRequest.fromString("pct:41.6,7.5,40,70");
-    assertThat(req).hasFieldOrPropertyWithValue("region", new Rectangle2D.Double(41.6, 7.5, 40, 70));
+    assertThat(req)
+        .hasFieldOrPropertyWithValue("region", new Rectangle2D.Double(41.6, 7.5, 40, 70));
     assertThat(req.toString()).isEqualTo("pct:41.6,7.5,40,70");
     assertThat(req.resolve(imageDims)).isEqualTo(new Rectangle(1599, 554, 1538, 5171));
 
     req = RegionRequest.fromString("125,15,200,200");
-    assertThat(req.resolve(new Dimension(300, 200)))
-      .isEqualTo(new Rectangle(125, 15, 175, 185));
+    assertThat(req.resolve(new Dimension(300, 200))).isEqualTo(new Rectangle(125, 15, 175, 185));
 
     req = RegionRequest.fromString("pct:41.6,7.5,66.6,100");
-    assertThat(req.resolve(new Dimension(300, 200)))
-      .isEqualTo(new Rectangle(125, 15, 175, 185));
+    assertThat(req.resolve(new Dimension(300, 200))).isEqualTo(new Rectangle(125, 15, 175, 185));
   }
 
   @Test
@@ -96,14 +100,16 @@ public class SelectorTest {
     assertThat(req.toString()).isEqualTo("!225,100");
     assertThat(req.isBestFit()).isTrue();
     assertThat(req.resolve(imageDim, profile)).isEqualTo(new Dimension(150, 100));
-    assertThat(SizeRequest.fromString("!100,100").resolve(imageDim, profile)).isEqualTo(new Dimension(100, 66));
+    assertThat(SizeRequest.fromString("!100,100").resolve(imageDim, profile))
+        .isEqualTo(new Dimension(100, 66));
 
     imageDim = new Dimension(200, 400);
     req = SizeRequest.fromString("!100,500");
     assertThat(req.toString()).isEqualTo("!100,500");
     assertThat(req.isBestFit()).isTrue();
     assertThat(req.resolve(imageDim, profile)).isEqualTo(new Dimension(100, 200));
-    assertThat(SizeRequest.fromString("!100,100").resolve(imageDim, profile)).isEqualTo(new Dimension(50, 100));
+    assertThat(SizeRequest.fromString("!100,100").resolve(imageDim, profile))
+        .isEqualTo(new Dimension(50, 100));
   }
 
   @Test
@@ -114,39 +120,41 @@ public class SelectorTest {
     profile.setMaxWidth(65000);
 
     assertThat(SizeRequest.fromString("max").resolve(imageDim, profile))
-      .isEqualTo(new Dimension(65000, 65000));
+        .isEqualTo(new Dimension(65000, 65000));
     assertThatExceptionOfType(ResolvingException.class)
-      .isThrownBy(() -> SizeRequest.fromString("full").resolve(imageDim, profile));
+        .isThrownBy(() -> SizeRequest.fromString("full").resolve(imageDim, profile));
     assertThatExceptionOfType(ResolvingException.class)
-      .isThrownBy(() -> SizeRequest.fromString("80000,").resolve(imageDim, profile));
+        .isThrownBy(() -> SizeRequest.fromString("80000,").resolve(imageDim, profile));
     assertThatExceptionOfType(ResolvingException.class)
-      .isThrownBy(() -> SizeRequest.fromString(",80000").resolve(imageDim, profile));
+        .isThrownBy(() -> SizeRequest.fromString(",80000").resolve(imageDim, profile));
     assertThatExceptionOfType(ResolvingException.class)
-      .isThrownBy(() -> SizeRequest.fromString("pct:80").resolve(imageDim, profile));
+        .isThrownBy(() -> SizeRequest.fromString("pct:80").resolve(imageDim, profile));
 
     assertThat(SizeRequest.fromString("max").resolve(stretchedDim, profile))
-      .isEqualTo(new Dimension(65, 65000));
+        .isEqualTo(new Dimension(65, 65000));
     assertThatExceptionOfType(ResolvingException.class)
-      .isThrownBy(() -> SizeRequest.fromString(",80000").resolve(stretchedDim, profile));
+        .isThrownBy(() -> SizeRequest.fromString(",80000").resolve(stretchedDim, profile));
     assertThatExceptionOfType(ResolvingException.class)
-      .isThrownBy(() -> SizeRequest.fromString("full").resolve(stretchedDim, profile));
+        .isThrownBy(() -> SizeRequest.fromString("full").resolve(stretchedDim, profile));
     assertThatExceptionOfType(ResolvingException.class)
-      .isThrownBy(() -> SizeRequest.fromString("70000,").resolve(new Dimension(100, 100), profile));
+        .isThrownBy(
+            () -> SizeRequest.fromString("70000,").resolve(new Dimension(100, 100), profile));
     assertThatExceptionOfType(ResolvingException.class)
-      .isThrownBy(() -> SizeRequest.fromString("50000,").resolve(new Dimension(100, 100), profile));
+        .isThrownBy(
+            () -> SizeRequest.fromString("50000,").resolve(new Dimension(100, 100), profile));
 
     profile.addFeature(ImageApiProfile.Feature.SIZE_ABOVE_FULL);
     Dimension smallDim = new Dimension(1024, 768);
     assertThat(SizeRequest.fromString("max").resolve(smallDim, profile))
-      .isEqualTo(new Dimension(1024, 768));
+        .isEqualTo(new Dimension(1024, 768));
     assertThat(SizeRequest.fromString("65000,").resolve(smallDim, profile))
-      .isEqualTo(new Dimension(65000, 48750));
+        .isEqualTo(new Dimension(65000, 48750));
 
     profile.setMaxArea((long) 1e6);
     assertThat(SizeRequest.fromString("max").resolve(imageDim, profile))
-      .isEqualTo(new Dimension(1000, 1000));
+        .isEqualTo(new Dimension(1000, 1000));
     assertThat(SizeRequest.fromString("max").resolve(stretchedDim, profile))
-      .isEqualTo(new Dimension(31, 31000));
+        .isEqualTo(new Dimension(31, 31000));
   }
 
   @Test
@@ -174,108 +182,113 @@ public class SelectorTest {
     ImageApiProfile profile = ImageApiProfile.LEVEL_TWO;
 
     assertThat(
-      ImageApiSelector.fromString("id/0,0,800,600/800,600/0/color.jpg")
-        .getCanonicalForm(nativeDims, profile, nativeQuality))
-      .isEqualTo("id/full/full/0/default.jpg");
+            ImageApiSelector.fromString("id/0,0,800,600/800,600/0/color.jpg")
+                .getCanonicalForm(nativeDims, profile, nativeQuality))
+        .isEqualTo("id/full/full/0/default.jpg");
     assertThat(
-      ImageApiSelector.fromString("id/pct:0,0,50.0,50.0/pct:50/0/gray.jpg")
-        .getCanonicalForm(nativeDims, profile, nativeQuality))
-      .isEqualTo("id/0,0,400,300/200,/0/gray.jpg");
+            ImageApiSelector.fromString("id/pct:0,0,50.0,50.0/pct:50/0/gray.jpg")
+                .getCanonicalForm(nativeDims, profile, nativeQuality))
+        .isEqualTo("id/0,0,400,300/200,/0/gray.jpg");
     assertThat(
-      ImageApiSelector.fromString("id/full/800,/0/gray.jpg")
-        .getCanonicalForm(nativeDims, profile, nativeQuality))
-      .isEqualTo("id/full/full/0/gray.jpg");
+            ImageApiSelector.fromString("id/full/800,/0/gray.jpg")
+                .getCanonicalForm(nativeDims, profile, nativeQuality))
+        .isEqualTo("id/full/full/0/gray.jpg");
     assertThat(
-      ImageApiSelector.fromString("id/full/400,300/0/default.png")
-        .getCanonicalForm(nativeDims, profile, nativeQuality))
-      .isEqualTo("id/full/400,/0/default.png");
+            ImageApiSelector.fromString("id/full/400,300/0/default.png")
+                .getCanonicalForm(nativeDims, profile, nativeQuality))
+        .isEqualTo("id/full/400,/0/default.png");
     assertThat(
-      ImageApiSelector.fromString("id/full/800,300/0/gray.jpg")
-        .getCanonicalForm(nativeDims, profile, nativeQuality))
-      .isEqualTo("id/full/800,300/0/gray.jpg");
+            ImageApiSelector.fromString("id/full/800,300/0/gray.jpg")
+                .getCanonicalForm(nativeDims, profile, nativeQuality))
+        .isEqualTo("id/full/800,300/0/gray.jpg");
     assertThat(
-      ImageApiSelector.fromString("id/full/1500,2240/0/gray.jpg")
-        .getCanonicalForm(new Dimension(2000, 2986), profile, nativeQuality))
-      .isEqualTo("id/full/1500,/0/gray.jpg");
+            ImageApiSelector.fromString("id/full/1500,2240/0/gray.jpg")
+                .getCanonicalForm(new Dimension(2000, 2986), profile, nativeQuality))
+        .isEqualTo("id/full/1500,/0/gray.jpg");
     assertThat(
-      ImageApiSelector.fromString("id/full/250,/0/gray.jpg")
-        .getCanonicalForm(new Dimension(2000, 2986), profile, nativeQuality))
-      .isEqualTo("id/full/250,/0/gray.jpg");
+            ImageApiSelector.fromString("id/full/250,/0/gray.jpg")
+                .getCanonicalForm(new Dimension(2000, 2986), profile, nativeQuality))
+        .isEqualTo("id/full/250,/0/gray.jpg");
   }
 
   @Test
   public void testUrlDecode() throws Exception {
     assertThat(ImageApiSelector.fromString("id1/full/full/0/default.png"))
-      .hasFieldOrPropertyWithValue("identifier", "id1")
-      .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("full"))
-      .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("full"))
-      .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("0"))
-      .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.DEFAULT)
-      .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.PNG)
-      .hasToString("id1/full/full/0/default.png");
+        .hasFieldOrPropertyWithValue("identifier", "id1")
+        .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("full"))
+        .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("full"))
+        .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("0"))
+        .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.DEFAULT)
+        .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.PNG)
+        .hasToString("id1/full/full/0/default.png");
 
     assertThat(ImageApiSelector.fromString("id1/0,10,100,200/pct:50/90/default.png"))
-      .hasFieldOrPropertyWithValue("identifier", "id1")
-      .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("0,10,100,200"))
-      .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("pct:50"))
-      .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("90"))
-      .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.DEFAULT)
-      .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.PNG)
-      .hasToString("id1/0,10,100,200/pct:50/90/default.png");
+        .hasFieldOrPropertyWithValue("identifier", "id1")
+        .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("0,10,100,200"))
+        .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("pct:50"))
+        .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("90"))
+        .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.DEFAULT)
+        .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.PNG)
+        .hasToString("id1/0,10,100,200/pct:50/90/default.png");
 
     assertThat(ImageApiSelector.fromString("id1/pct:10,10,80,80/50,/22.5/color.jpg"))
-      .hasFieldOrPropertyWithValue("identifier", "id1")
-      .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("pct:10,10,80,80"))
-      .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("50,"))
-      .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("22.5"))
-      .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.COLOR)
-      .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.JPG)
-      .hasToString("id1/pct:10,10,80,80/50,/22.5/color.jpg");
+        .hasFieldOrPropertyWithValue("identifier", "id1")
+        .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("pct:10,10,80,80"))
+        .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("50,"))
+        .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("22.5"))
+        .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.COLOR)
+        .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.JPG)
+        .hasToString("id1/pct:10,10,80,80/50,/22.5/color.jpg");
 
     assertThat(ImageApiSelector.fromString("bb157hs6068/full/full/270/gray.jpg"))
-      .hasFieldOrPropertyWithValue("identifier", "bb157hs6068")
-      .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("full"))
-      .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("full"))
-      .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("270"))
-      .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.GRAY)
-      .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.JPG)
-      .hasToString("bb157hs6068/full/full/270/gray.jpg");
+        .hasFieldOrPropertyWithValue("identifier", "bb157hs6068")
+        .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("full"))
+        .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("full"))
+        .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("270"))
+        .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.GRAY)
+        .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.JPG)
+        .hasToString("bb157hs6068/full/full/270/gray.jpg");
 
     assertThat(ImageApiSelector.fromString("ark:%2F12025%2F654xz321/full/full/0/default.jpg"))
-      .hasFieldOrPropertyWithValue("identifier", "ark:/12025/654xz321")
-      .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("full"))
-      .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("full"))
-      .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("0"))
-      .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.DEFAULT)
-      .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.JPG)
-      .hasToString("ark:%2F12025%2F654xz321/full/full/0/default.jpg");
+        .hasFieldOrPropertyWithValue("identifier", "ark:/12025/654xz321")
+        .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("full"))
+        .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("full"))
+        .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("0"))
+        .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.DEFAULT)
+        .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.JPG)
+        .hasToString("ark:%2F12025%2F654xz321/full/full/0/default.jpg");
 
     assertThat(ImageApiSelector.fromString("urn:foo:a123,456/full/full/0/default.jpg"))
-      .hasFieldOrPropertyWithValue("identifier", "urn:foo:a123,456")
-      .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("full"))
-      .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("full"))
-      .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("0"))
-      .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.DEFAULT)
-      .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.JPG)
-      .hasToString("urn:foo:a123,456/full/full/0/default.jpg");
+        .hasFieldOrPropertyWithValue("identifier", "urn:foo:a123,456")
+        .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("full"))
+        .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("full"))
+        .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("0"))
+        .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.DEFAULT)
+        .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.JPG)
+        .hasToString("urn:foo:a123,456/full/full/0/default.jpg");
 
-    assertThat(ImageApiSelector.fromString("urn:sici:1046-8188(199501)13:1%253C69:FTTHBI%253E2.0.TX;2-4/full/full/0/default.jpg"))
-      .hasFieldOrPropertyWithValue("identifier", "urn:sici:1046-8188(199501)13:1%3C69:FTTHBI%3E2.0.TX;2-4")
-      .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("full"))
-      .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("full"))
-      .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("0"))
-      .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.DEFAULT)
-      .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.JPG)
-      .hasToString("urn:sici:1046-8188(199501)13:1%253C69:FTTHBI%253E2.0.TX;2-4/full/full/0/default.jpg");
+    assertThat(
+            ImageApiSelector.fromString(
+                "urn:sici:1046-8188(199501)13:1%253C69:FTTHBI%253E2.0.TX;2-4/full/full/0/default.jpg"))
+        .hasFieldOrPropertyWithValue(
+            "identifier", "urn:sici:1046-8188(199501)13:1%3C69:FTTHBI%3E2.0.TX;2-4")
+        .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("full"))
+        .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("full"))
+        .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("0"))
+        .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.DEFAULT)
+        .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.JPG)
+        .hasToString(
+            "urn:sici:1046-8188(199501)13:1%253C69:FTTHBI%253E2.0.TX;2-4/full/full/0/default.jpg");
 
-    assertThat(ImageApiSelector.fromString("http:%2F%2Fexample.com%2F%3F54%23a/full/full/0/default.jpg"))
-      .hasFieldOrPropertyWithValue("identifier", "http://example.com/?54#a")
-      .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("full"))
-      .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("full"))
-      .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("0"))
-      .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.DEFAULT)
-      .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.JPG)
-      .hasToString("http:%2F%2Fexample.com%2F%3F54%23a/full/full/0/default.jpg");
+    assertThat(
+            ImageApiSelector.fromString(
+                "http:%2F%2Fexample.com%2F%3F54%23a/full/full/0/default.jpg"))
+        .hasFieldOrPropertyWithValue("identifier", "http://example.com/?54#a")
+        .hasFieldOrPropertyWithValue("region", RegionRequest.fromString("full"))
+        .hasFieldOrPropertyWithValue("size", SizeRequest.fromString("full"))
+        .hasFieldOrPropertyWithValue("rotation", RotationRequest.fromString("0"))
+        .hasFieldOrPropertyWithValue("quality", ImageApiProfile.Quality.DEFAULT)
+        .hasFieldOrPropertyWithValue("format", ImageApiProfile.Format.JPG)
+        .hasToString("http:%2F%2Fexample.com%2F%3F54%23a/full/full/0/default.jpg");
   }
-
 }

--- a/src/test/java/de/digitalcollections/iiif/model/image/SpecExamplesDeserializationTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/image/SpecExamplesDeserializationTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.model.image;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import de.digitalcollections.iiif.model.annex.GeoService;
@@ -15,8 +17,6 @@ import java.util.Locale;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class SpecExamplesDeserializationTest {
 
   private ObjectMapper mapper;
@@ -27,58 +27,61 @@ public class SpecExamplesDeserializationTest {
   }
 
   private <T> T readFromResources(String filename, Class<T> clz) throws IOException {
-    return mapper.readValue(
-      Resources.getResource("spec/image/" + filename), clz);
+    return mapper.readValue(Resources.getResource("spec/image/" + filename), clz);
   }
 
   @Test
   public void testFullResponse() throws Exception {
     ImageService imageService = readFromResources("fullResponse.json", ImageService.class);
     assertThat(imageService)
-      .hasFieldOrPropertyWithValue("width", 6000)
-      .hasFieldOrPropertyWithValue("height", 4000);
+        .hasFieldOrPropertyWithValue("width", 6000)
+        .hasFieldOrPropertyWithValue("height", 4000);
     assertThat(imageService.getIdentifier().toString())
-      .isEqualTo("http://www.example.org/image-service/abcd1234/1E34750D-38DB-4825-A38A-B60A345E591C");
-    assertThat(imageService.getSizes()).containsExactly(
-      new Size(150, 100),
-      new Size(600, 400),
-      new Size(3000, 2000));
+        .isEqualTo(
+            "http://www.example.org/image-service/abcd1234/1E34750D-38DB-4825-A38A-B60A345E591C");
+    assertThat(imageService.getSizes())
+        .containsExactly(new Size(150, 100), new Size(600, 400), new Size(3000, 2000));
     assertThat(imageService.getTiles().get(0).getWidth()).isEqualTo(512);
     assertThat(imageService.getTiles().get(0).getScaleFactors()).containsExactly(1, 2, 4);
     assertThat(imageService.getTiles().get(1))
-      .hasFieldOrPropertyWithValue("width", 1024)
-      .hasFieldOrPropertyWithValue("height", 2048);
+        .hasFieldOrPropertyWithValue("width", 1024)
+        .hasFieldOrPropertyWithValue("height", 2048);
     assertThat(imageService.getTiles().get(1).getScaleFactors()).containsExactly(8, 16);
     assertThat(imageService.getAttribution().getLocalizations())
-      .containsExactly(Locale.ENGLISH, Locale.forLanguageTag("cy"));
+        .containsExactly(Locale.ENGLISH, Locale.forLanguageTag("cy"));
     assertThat(imageService.getAttribution().getValues(Locale.ENGLISH))
-      .containsExactly("<span>Provided by Example Organization</span>");
+        .containsExactly("<span>Provided by Example Organization</span>");
     assertThat(imageService.getAttribution().getValues(Locale.forLanguageTag("cy")))
-      .containsExactly("<span>Darparwyd gan Enghraifft Sefydliad</span>");
+        .containsExactly("<span>Darparwyd gan Enghraifft Sefydliad</span>");
     assertThat(imageService.getLogos()).hasSize(1);
     assertThat(imageService.getLogos().get(0).getServices().get(0).getProfiles())
-      .containsExactly(ImageApiProfile.LEVEL_TWO);
+        .containsExactly(ImageApiProfile.LEVEL_TWO);
     assertThat(imageService.getLicenses().stream().map(URI::toString))
-      .containsExactly("http://example.org/rights/license1.html",
-        "http://rightsstatements.org/vocab/InC-EDU/1.0/");
+        .containsExactly(
+            "http://example.org/rights/license1.html",
+            "http://rightsstatements.org/vocab/InC-EDU/1.0/");
     assertThat(imageService.getProfiles().get(0)).isEqualTo(ImageApiProfile.LEVEL_TWO);
     ImageApiProfile complexProfile = (ImageApiProfile) imageService.getProfiles().get(1);
-    assertThat(complexProfile.getFormats())
-      .containsExactlyInAnyOrder(Format.GIF, Format.PDF);
+    assertThat(complexProfile.getFormats()).containsExactlyInAnyOrder(Format.GIF, Format.PDF);
     assertThat(complexProfile.getQualities())
-      .containsExactlyInAnyOrder(Quality.COLOR, Quality.GRAY);
-    assertThat(complexProfile.getFeatures()).containsExactlyInAnyOrder(
-      Feature.CANONICAL_LINK_HEADER, Feature.ROTATION_ARBITRARY, Feature.PROFILE_LINK_HEADER,
-      new Feature("http://example.com/feature/"));
+        .containsExactlyInAnyOrder(Quality.COLOR, Quality.GRAY);
+    assertThat(complexProfile.getFeatures())
+        .containsExactlyInAnyOrder(
+            Feature.CANONICAL_LINK_HEADER,
+            Feature.ROTATION_ARBITRARY,
+            Feature.PROFILE_LINK_HEADER,
+            new Feature("http://example.com/feature/"));
 
     assertThat(imageService.getServices().get(0)).isInstanceOf(PhysicalDimensionsService.class);
-    PhysicalDimensionsService physService = (PhysicalDimensionsService) imageService.getServices().get(0);
+    PhysicalDimensionsService physService =
+        (PhysicalDimensionsService) imageService.getServices().get(0);
     assertThat(physService)
-      .hasFieldOrPropertyWithValue("physicalScale", 0.0025)
-      .hasFieldOrPropertyWithValue("physicalUnits", Unit.INCHES);
+        .hasFieldOrPropertyWithValue("physicalScale", 0.0025)
+        .hasFieldOrPropertyWithValue("physicalUnits", Unit.INCHES);
 
     assertThat(imageService.getServices().get(1)).isInstanceOf(GeoService.class);
     GeoService geoService = (GeoService) imageService.getServices().get(1);
-    assertThat(geoService.getIdentifier().toString()).isEqualTo("http://www.example.org/geojson/paris.json");
+    assertThat(geoService.getIdentifier().toString())
+        .isEqualTo("http://www.example.org/geojson/paris.json");
   }
 }

--- a/src/test/java/de/digitalcollections/iiif/model/image/SpecExamplesSerializationTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/image/SpecExamplesSerializationTest.java
@@ -31,10 +31,11 @@ public class SpecExamplesSerializationTest {
 
   private String readFromResources(String filename) throws IOException {
     return Resources.toString(
-      Resources.getResource("spec/image/" + filename), Charset.defaultCharset());
+        Resources.getResource("spec/image/" + filename), Charset.defaultCharset());
   }
 
-  private void assertSerializationEqualsSpec(Object obj, String specFilename) throws IOException, JSONException {
+  private void assertSerializationEqualsSpec(Object obj, String specFilename)
+      throws IOException, JSONException {
     String specJson = readFromResources(specFilename);
     String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
     JSONAssert.assertEquals(specJson, json, true);
@@ -42,13 +43,13 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testFullResponse() throws Exception {
-    ImageService service = new ImageService("http://www.example.org/image-service/abcd1234/1E34750D-38DB-4825-A38A-B60A345E591C", ImageApiProfile.LEVEL_TWO);
+    ImageService service =
+        new ImageService(
+            "http://www.example.org/image-service/abcd1234/1E34750D-38DB-4825-A38A-B60A345E591C",
+            ImageApiProfile.LEVEL_TWO);
     service.setWidth(6000);
     service.setHeight(4000);
-    service.addSize(
-      new Size(150, 100),
-      new Size(600, 400),
-      new Size(3000, 2000));
+    service.addSize(new Size(150, 100), new Size(600, 400), new Size(3000, 2000));
 
     TileInfo ti1 = new TileInfo(512);
     ti1.addScaleFactor(1, 2, 4);
@@ -59,27 +60,34 @@ public class SpecExamplesSerializationTest {
 
     PropertyValue attribution = new PropertyValue();
     attribution.addValue(Locale.ENGLISH, "<span>Provided by Example Organization</span>");
-    attribution.addValue(Locale.forLanguageTag("cy"), "<span>Darparwyd gan Enghraifft Sefydliad</span>");
+    attribution.addValue(
+        Locale.forLanguageTag("cy"), "<span>Darparwyd gan Enghraifft Sefydliad</span>");
     service.setAttribution(attribution);
 
-    ImageContent logo = new ImageContent("http://example.org/image-service/logo/full/200,/0/default.png");
-    logo.addService(new ImageService("http://example.org/image-service/logo", ImageApiProfile.LEVEL_TWO));
+    ImageContent logo =
+        new ImageContent("http://example.org/image-service/logo/full/200,/0/default.png");
+    logo.addService(
+        new ImageService("http://example.org/image-service/logo", ImageApiProfile.LEVEL_TWO));
     logo.setFormat((MimeType) null);
     service.addLogo(logo);
 
-    service.addLicense("http://example.org/rights/license1.html",
-      "http://rightsstatements.org/vocab/InC-EDU/1.0/");
+    service.addLicense(
+        "http://example.org/rights/license1.html",
+        "http://rightsstatements.org/vocab/InC-EDU/1.0/");
 
     ImageApiProfile profile = new ImageApiProfile();
     profile.addFormat(Format.GIF, Format.PDF);
     profile.addQuality(Quality.COLOR, Quality.GRAY);
-    profile.addFeature(Feature.CANONICAL_LINK_HEADER, Feature.ROTATION_ARBITRARY, Feature.PROFILE_LINK_HEADER,
-      new Feature("http://example.com/feature/"));
+    profile.addFeature(
+        Feature.CANONICAL_LINK_HEADER,
+        Feature.ROTATION_ARBITRARY,
+        Feature.PROFILE_LINK_HEADER,
+        new Feature("http://example.com/feature/"));
     service.addProfile(profile);
 
     service.addService(
-      new PhysicalDimensionsService(0.0025, Unit.INCHES),
-      new GeoService("http://www.example.org/geojson/paris.json"));
+        new PhysicalDimensionsService(0.0025, Unit.INCHES),
+        new GeoService("http://www.example.org/geojson/paris.json"));
 
     assertSerializationEqualsSpec(service, "fullResponse.json");
   }

--- a/src/test/java/de/digitalcollections/iiif/model/package-info.java
+++ b/src/test/java/de/digitalcollections/iiif/model/package-info.java
@@ -1,14 +1,13 @@
 /**
- * The bulk of the tests are based on the inline examples in the IIIF specifications
- * and can be found in the following packages:
+ * The bulk of the tests are based on the inline examples in the IIIF specifications and can be
+ * found in the following packages:
  *
- * - {@link de.digitalcollections.iiif.model.presentation}
- * - {@link de.digitalcollections.iiif.model.image}
- * - {@link de.digitalcollections.iiif.model.search}
- * - {@link de.digitalcollections.iiif.model.annex}
+ * <p>- {@link de.digitalcollections.iiif.model.presentation} - {@link
+ * de.digitalcollections.iiif.model.image} - {@link de.digitalcollections.iiif.model.search} -
+ * {@link de.digitalcollections.iiif.model.annex}
  *
- * If you are looking for simple usage examples to get started, look into
- * {@link de.digitalcollections.iiif.model.JsonMappingTest} and
- * {@link de.digitalcollections.iiif.model.ParsingTest}.
+ * <p>If you are looking for simple usage examples to get started, look into {@link
+ * de.digitalcollections.iiif.model.JsonMappingTest} and {@link
+ * de.digitalcollections.iiif.model.ParsingTest}.
  */
 package de.digitalcollections.iiif.model;

--- a/src/test/java/de/digitalcollections/iiif/model/presentation/SpecExamplesDeserializationTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/presentation/SpecExamplesDeserializationTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.model.presentation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import de.digitalcollections.iiif.model.ImageContent;
@@ -31,8 +33,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class SpecExamplesDeserializationTest {
 
   private ObjectMapper mapper;
@@ -43,8 +43,7 @@ public class SpecExamplesDeserializationTest {
   }
 
   private <T> T readFromResources(String filename, Class<T> clz) throws IOException {
-    return mapper.readValue(
-      Resources.getResource("spec/presentation/" + filename), clz);
+    return mapper.readValue(Resources.getResource("spec/presentation/" + filename), clz);
   }
 
   @Test
@@ -52,60 +51,66 @@ public class SpecExamplesDeserializationTest {
     Manifest manifest = readFromResources("full_response.json", Manifest.class);
     assertThat(manifest).isNotNull();
     assertThat(manifest.getIdentifier().toString())
-      .isEqualTo("http://example.org/iiif/book1/manifest");
-    assertThat(manifest.getLabel().getValues())
-      .hasSize(1);
-    assertThat(manifest.getLabelString())
-      .isEqualTo("Book 1");
-    assertThat(manifest.getMetadata())
-      .hasSize(2);
+        .isEqualTo("http://example.org/iiif/book1/manifest");
+    assertThat(manifest.getLabel().getValues()).hasSize(1);
+    assertThat(manifest.getLabelString()).isEqualTo("Book 1");
+    assertThat(manifest.getMetadata()).hasSize(2);
     assertThat(manifest.getMetadata().get(1).getValue().getLocalizations())
-      .containsExactlyInAnyOrder(Locale.ENGLISH, Locale.FRENCH);
+        .containsExactlyInAnyOrder(Locale.ENGLISH, Locale.FRENCH);
     assertThat(manifest.getNavDate()).isEqualTo("1856-01-01T00:00:00Z");
 
     assertThat(manifest.getServices().get(0).getContext().toString())
-      .isEqualTo("http://example.org/ns/jsonld/context.json");
+        .isEqualTo("http://example.org/ns/jsonld/context.json");
     assertThat(manifest.getServices().get(0))
-      .hasFieldOrPropertyWithValue("identifier", URI.create("http://example.org/service/example"));
+        .hasFieldOrPropertyWithValue(
+            "identifier", URI.create("http://example.org/service/example"));
     assertThat(manifest.getServices().get(0).getProfiles())
-      .containsExactly(new Profile(URI.create("http://example.org/docs/example-service.html")));
+        .containsExactly(new Profile(URI.create("http://example.org/docs/example-service.html")));
 
     assertThat(manifest.getSeeAlso().get(0).getFormat())
-      .isEqualTo(MimeType.fromTypename("application/marc"));
+        .isEqualTo(MimeType.fromTypename("application/marc"));
     assertThat(manifest.getRenderings().get(0).getFormat())
-      .isEqualTo(MimeType.fromTypename("application/pdf"));
+        .isEqualTo(MimeType.fromTypename("application/pdf"));
     assertThat(manifest.getWithin().get(0))
-      .isInstanceOf(Collection.class)
-      .hasFieldOrPropertyWithValue("identifier", URI.create("http://example.org/collections/books/"));
+        .isInstanceOf(Collection.class)
+        .hasFieldOrPropertyWithValue(
+            "identifier", URI.create("http://example.org/collections/books/"));
 
     assertThat(manifest.getDefaultSequence().getCanvases()).hasSize(3);
     Canvas firstCanvas = manifest.getDefaultSequence().getCanvases().get(0);
     assertThat(firstCanvas.getHeight()).isEqualTo(1000);
-    assertThat(firstCanvas.getImages().get(0).getOn())
-      .isInstanceOf(Canvas.class);
+    assertThat(firstCanvas.getImages().get(0).getOn()).isInstanceOf(Canvas.class);
     assertThat(firstCanvas.getImages().get(0).getResource())
-      .isInstanceOf(ImageContent.class)
-      .hasFieldOrPropertyWithValue("format", MimeType.MIME_IMAGE_JPEG)
-      .hasFieldOrPropertyWithValue("height", 2000);
+        .isInstanceOf(ImageContent.class)
+        .hasFieldOrPropertyWithValue("format", MimeType.MIME_IMAGE_JPEG)
+        .hasFieldOrPropertyWithValue("height", 2000);
     Assertions.assertThat(firstCanvas.getImages().get(0).getResource().getServices().get(0))
-      .isInstanceOf(ImageService.class);
+        .isInstanceOf(ImageService.class);
 
     assertThat(firstCanvas.getOtherContent().get(0).getWithin().get(0))
-      .isInstanceOf(Layer.class)
-      .hasFieldOrPropertyWithValue("identifier", URI.create("http://example.org/iiif/book1/layer/l1"));
+        .isInstanceOf(Layer.class)
+        .hasFieldOrPropertyWithValue(
+            "identifier", URI.create("http://example.org/iiif/book1/layer/l1"));
 
-    assertThat(manifest.getDefaultSequence().getCanvases().get(1)
-      .getOtherContent().get(0)
-      .getWithin().get(0))
-      .isInstanceOf(Layer.class)
-      .hasFieldOrPropertyWithValue("identifier", URI.create("http://example.org/iiif/book1/layer/l1"));
+    assertThat(
+            manifest
+                .getDefaultSequence()
+                .getCanvases()
+                .get(1)
+                .getOtherContent()
+                .get(0)
+                .getWithin()
+                .get(0))
+        .isInstanceOf(Layer.class)
+        .hasFieldOrPropertyWithValue(
+            "identifier", URI.create("http://example.org/iiif/book1/layer/l1"));
 
     assertThat(manifest.getRanges()).hasSize(1);
-    assertThat(manifest.getRanges().get(0).getLabelString())
-      .isEqualTo("Introduction");
+    assertThat(manifest.getRanges().get(0).getLabelString()).isEqualTo("Introduction");
     assertThat(manifest.getRanges().get(0).getCanvases()).hasSize(3);
     assertThat(manifest.getRanges().get(0).getCanvases())
-      .allMatch(c -> c.getIdentifier().toString().startsWith("http://example.org/iiif/book1/canvas/p"));
+        .allMatch(
+            c -> c.getIdentifier().toString().startsWith("http://example.org/iiif/book1/canvas/p"));
   }
 
   @Test
@@ -113,28 +118,28 @@ public class SpecExamplesDeserializationTest {
     AnnotationList annoList = readFromResources("annotationList.json", AnnotationList.class);
     assertThat(annoList).isNotNull();
     assertThat(annoList.getIdentifier().toString())
-      .isEqualTo("http://example.org/iiif/book1/list/p1");
+        .isEqualTo("http://example.org/iiif/book1/list/p1");
     assertThat(annoList.getResources()).hasSize(2);
-    assertThat(annoList.getResources().get(0).getOn())
-      .isInstanceOf(Canvas.class);
+    assertThat(annoList.getResources().get(0).getOn()).isInstanceOf(Canvas.class);
     assertThat(annoList.getResources().get(0).getResource())
-      .isInstanceOf(OtherContent.class)
-      .hasFieldOrPropertyWithValue("type", "dctypes:Sound")
-      .hasFieldOrPropertyWithValue("format", MimeType.fromTypename("audio/mpeg"));
+        .isInstanceOf(OtherContent.class)
+        .hasFieldOrPropertyWithValue("type", "dctypes:Sound")
+        .hasFieldOrPropertyWithValue("format", MimeType.fromTypename("audio/mpeg"));
   }
 
   @Test
   public void testAnnotationListWithTranscription() throws IOException {
-    AnnotationList annoList = readFromResources("annotationListWithTranscription.json", AnnotationList.class);
+    AnnotationList annoList =
+        readFromResources("annotationListWithTranscription.json", AnnotationList.class);
     assertThat(annoList).isNotNull();
     assertThat(annoList.getResources().get(0).getIdentifier().toString())
-      .isEqualTo("http://example.org/iiif/book1/annotation/anno1");
+        .isEqualTo("http://example.org/iiif/book1/annotation/anno1");
     assertThat(annoList.getResources().get(0).getOn().getIdentifier().toString())
-      .isEqualTo("http://example.org/iiif/book1/canvas/p1#xywh=100,100,300,300");
-    assertThat(annoList.getResources().get(0).getResource())
-      .isInstanceOf(SpecificResource.class);
+        .isEqualTo("http://example.org/iiif/book1/canvas/p1#xywh=100,100,300,300");
+    assertThat(annoList.getResources().get(0).getResource()).isInstanceOf(SpecificResource.class);
 
-    SpecificResource specificResource = (SpecificResource) annoList.getResources().get(0).getResource();
+    SpecificResource specificResource =
+        (SpecificResource) annoList.getResources().get(0).getResource();
     ContentAsText full = (ContentAsText) specificResource.getFull();
     assertThat(full.getChars()).isEqualTo("Here starts book one...");
     assertThat(full.getFormat().getTypeName()).isEqualTo("text/plain");
@@ -145,15 +150,14 @@ public class SpecExamplesDeserializationTest {
 
   @Test
   public void testAnnotationListWithinLayer() throws IOException {
-    AnnotationList annoList = readFromResources("annotationListWithinLayer.json", AnnotationList.class);
+    AnnotationList annoList =
+        readFromResources("annotationListWithinLayer.json", AnnotationList.class);
     assertThat(annoList).isNotNull();
     assertThat(annoList.getWithin()).hasSize(1);
-    assertThat(annoList.getWithin().get(0))
-      .isInstanceOf(Layer.class);
+    assertThat(annoList.getWithin().get(0)).isInstanceOf(Layer.class);
     assertThat(annoList.getWithin().get(0).getIdentifier().toString())
-      .isEqualTo("http://example.org/iiif/book1/layer/transcription");
-    assertThat(annoList.getWithin().get(0).getLabelString())
-      .isEqualTo("Diplomatic Transcription");
+        .isEqualTo("http://example.org/iiif/book1/layer/transcription");
+    assertThat(annoList.getWithin().get(0).getLabelString()).isEqualTo("Diplomatic Transcription");
   }
 
   @Test
@@ -170,8 +174,7 @@ public class SpecExamplesDeserializationTest {
     assertThat(anno).isNotNull();
     assertThat(anno.getResource()).isInstanceOf(ImageContent.class);
     assertThat(anno.getResource().getAlternatives()).isNotEmpty();
-    assertThat(anno.getResource().getAlternatives())
-      .allMatch(ImageContent.class::isInstance);
+    assertThat(anno.getResource().getAlternatives()).allMatch(ImageContent.class::isInstance);
     assertThat(anno.getOn()).isInstanceOf(Canvas.class);
   }
 
@@ -183,7 +186,8 @@ public class SpecExamplesDeserializationTest {
     assertThat(annoList.getWithin()).hasSize(1);
     assertThat(annoList.getWithin().get(0)).isInstanceOf(Layer.class);
     assertThat(annoList.getNext()).isInstanceOf(AnnotationList.class);
-    assertThat(annoList.getNext().getIdentifier().toString()).isEqualTo("http://example.org/iiif/book1/list/l2");
+    assertThat(annoList.getNext().getIdentifier().toString())
+        .isEqualTo("http://example.org/iiif/book1/list/l2");
   }
 
   @Test
@@ -219,9 +223,9 @@ public class SpecExamplesDeserializationTest {
     assertThat(anno.getResource()).isInstanceOf(ImageContent.class);
     ImageContent img = (ImageContent) anno.getResource();
     assertThat(img)
-      .hasFieldOrPropertyWithValue("format", MimeType.MIME_IMAGE_JPEG)
-      .hasFieldOrPropertyWithValue("width", 1500)
-      .hasFieldOrPropertyWithValue("height", 2000);
+        .hasFieldOrPropertyWithValue("format", MimeType.MIME_IMAGE_JPEG)
+        .hasFieldOrPropertyWithValue("width", 1500)
+        .hasFieldOrPropertyWithValue("height", 2000);
     assertThat(img.getServices().get(0)).isInstanceOf(ImageService.class);
     ImageService imgService = (ImageService) img.getServices().get(0);
     assertThat(imgService.getProfiles()).containsExactly(ImageApiProfile.LEVEL_TWO);
@@ -233,7 +237,7 @@ public class SpecExamplesDeserializationTest {
     assertThat(selector).isNotNull();
     assertThat(selector.getRegion().toString()).isEqualTo("50,50,1250,1850");
     assertThat(selector.asImageApiUri(URI.create("http://example.com/iiif/foobar")).toString())
-      .isEqualTo("http://example.com/iiif/foobar/50,50,1250,1850/full/0/default.jpg");
+        .isEqualTo("http://example.com/iiif/foobar/50,50,1250,1850/full/0/default.jpg");
   }
 
   @Test
@@ -251,23 +255,21 @@ public class SpecExamplesDeserializationTest {
     // NOTE: Only testing stuff not yet tested in testFullResponse
     ImageContent thumb = manifest.getThumbnail();
     assertThat(thumb.getIdentifier().toString())
-      .isEqualTo("http://example.org/images/book1-page1/full/80,100/0/default.jpg");
+        .isEqualTo("http://example.org/images/book1-page1/full/80,100/0/default.jpg");
     assertThat(thumb.getServices().get(0)).isInstanceOf(ImageService.class);
-    assertThat(thumb.getServices().get(0).getProfiles())
-      .containsExactly(ImageApiProfile.LEVEL_ONE);
+    assertThat(thumb.getServices().get(0).getProfiles()).containsExactly(ImageApiProfile.LEVEL_ONE);
     assertThat(manifest.getViewingDirection()).isEqualTo(ViewingDirection.RIGHT_TO_LEFT);
     assertThat(manifest.getViewingHints()).containsExactly(ViewingHint.PAGED);
     assertThat(manifest.getLogos()).hasSize(1);
     assertThat(manifest.getRelated().get(0).getFormat())
-      .isEqualTo(MimeType.fromTypename("video/mpeg"));
+        .isEqualTo(MimeType.fromTypename("video/mpeg"));
     assertThat(manifest.getSeeAlso().get(0))
-      .hasFieldOrPropertyWithValue("format", MimeType.fromTypename("text/xml"));
+        .hasFieldOrPropertyWithValue("format", MimeType.fromTypename("text/xml"));
     assertThat(manifest.getSeeAlso().get(0).getProfile().getIdentifier())
-      .isEqualTo(URI.create("http://example.org/profiles/bibliographic"));
+        .isEqualTo(URI.create("http://example.org/profiles/bibliographic"));
     assertThat(manifest.getRenderings().get(0).getFormat())
-      .isEqualTo(MimeType.fromTypename("application/pdf"));
-    assertThat(manifest.getRenderings().get(0).getLabelString())
-      .isEqualTo("Download as PDF");
+        .isEqualTo(MimeType.fromTypename("application/pdf"));
+    assertThat(manifest.getRenderings().get(0).getLabelString()).isEqualTo("Download as PDF");
     assertThat(manifest.getWithin().get(0)).isInstanceOf(Collection.class);
     assertThat(manifest.getDefaultSequence().getLabelString()).isEqualTo("Current Page Order");
   }
@@ -322,8 +324,7 @@ public class SpecExamplesDeserializationTest {
     Annotation anno = readFromResources("specificResourceAnnotation.json", Annotation.class);
     assertThat(anno.getResource()).isInstanceOf(SpecificResource.class);
     SpecificResource res = (SpecificResource) anno.getResource();
-    assertThat(res.getFull())
-      .isInstanceOf(ImageContent.class);
+    assertThat(res.getFull()).isInstanceOf(ImageContent.class);
     assertThat(res.getSelector()).isInstanceOf(ImageApiSelector.class);
   }
 
@@ -344,16 +345,13 @@ public class SpecExamplesDeserializationTest {
     SpecificResource res = (SpecificResource) anno.getResource();
     assertThat(res.getSelector()).isInstanceOf(SvgSelector.class);
     assertThat(((SvgSelector) res.getSelector()).getChars())
-      .isEqualTo("<svg xmlns=\"...\"><path d=\"...\"/></svg>");
+        .isEqualTo("<svg xmlns=\"...\"><path d=\"...\"/></svg>");
   }
 
   @Test
   public void testStylesheet() throws Exception {
     Annotation anno = readFromResources("stylesheet.json", Annotation.class);
-    assertThat(anno.getStylesheet().getChars())
-      .isEqualTo(".red {color: red;}");
-    assertThat(((SpecificResource) anno.getResource()).getStyle())
-      .isEqualTo("red");
+    assertThat(anno.getStylesheet().getChars()).isEqualTo(".red {color: red;}");
+    assertThat(((SpecificResource) anno.getResource()).getStyle()).isEqualTo("red");
   }
-
 }

--- a/src/test/java/de/digitalcollections/iiif/model/presentation/SpecExamplesSerializationTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/presentation/SpecExamplesSerializationTest.java
@@ -52,10 +52,11 @@ public class SpecExamplesSerializationTest {
 
   private String readFromResources(String filename) throws IOException {
     return Resources.toString(
-      Resources.getResource("spec/presentation/" + filename), Charset.defaultCharset());
+        Resources.getResource("spec/presentation/" + filename), Charset.defaultCharset());
   }
 
-  private void assertSerializationEqualsSpec(Object obj, String specFilename) throws IOException, JSONException {
+  private void assertSerializationEqualsSpec(Object obj, String specFilename)
+      throws IOException, JSONException {
     String specJson = readFromResources(specFilename);
     String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
     JSONAssert.assertEquals(specJson, json, true);
@@ -63,27 +64,28 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testFullResponse() throws IOException, JSONException {
-    Manifest manifest = new Manifest("http://example.org/iiif/book1/manifest",
-      "Book 1");
+    Manifest manifest = new Manifest("http://example.org/iiif/book1/manifest", "Book 1");
     manifest.addMetadata("Author", "Anne Author");
     PropertyValue multiValue = new PropertyValue();
     multiValue.addValue(Locale.ENGLISH, "Paris, circa 1400");
     multiValue.addValue(Locale.FRENCH, "Paris, environ 14eme siecle");
-    manifest.addMetadata(new MetadataEntry(new PropertyValue("Published"),
-      multiValue));
-    manifest.addDescription("A longer description of this example book. It should give some real information.");
+    manifest.addMetadata(new MetadataEntry(new PropertyValue("Published"), multiValue));
+    manifest.addDescription(
+        "A longer description of this example book. It should give some real information.");
     manifest.setNavDate(OffsetDateTime.of(1856, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
     manifest.addLicense("https://creativecommons.org/publicdomain/zero/1.0/");
     manifest.addAttribution("Provided by Example Organization");
 
-    manifest.addService(new GenericService(
-      "http://example.org/ns/jsonld/context.json",
-      "http://example.org/service/example",
-      "http://example.org/docs/example-service.html"));
-    manifest.addSeeAlso(new OtherContent(
-      "http://example.org/library/catalog/book1.marc",
-      "application/marc",
-      "http://example.org/profiles/marc21"));
+    manifest.addService(
+        new GenericService(
+            "http://example.org/ns/jsonld/context.json",
+            "http://example.org/service/example",
+            "http://example.org/docs/example-service.html"));
+    manifest.addSeeAlso(
+        new OtherContent(
+            "http://example.org/library/catalog/book1.marc",
+            "application/marc",
+            "http://example.org/profiles/marc21"));
     OtherContent rendering = new OtherContent("http://example.org/iiif/book1.pdf");
     rendering.addLabel("Download as PDF");
     manifest.addRendering(rendering);
@@ -96,7 +98,8 @@ public class SpecExamplesSerializationTest {
 
     Canvas canvas = new Canvas("http://example.org/iiif/book1/canvas/p1", "p. 1");
     ImageContent img = new ImageContent("http://example.org/iiif/book1/res/page1.jpg");
-    img.addService(new ImageService("http://example.org/images/book1-page1", ImageApiProfile.LEVEL_ONE));
+    img.addService(
+        new ImageService("http://example.org/images/book1-page1", ImageApiProfile.LEVEL_ONE));
     img.setWidth(1500);
     img.setHeight(2000);
     canvas.addImage(img);
@@ -111,7 +114,8 @@ public class SpecExamplesSerializationTest {
     canvas.setWidth(750);
     canvas.setHeight(1000);
     img = new ImageContent("http://example.org/images/book1-page2/full/1500,2000/0/default.jpg");
-    ImageService imgService = new ImageService("http://example.org/images/book1-page2", ImageApiProfile.LEVEL_ONE);
+    ImageService imgService =
+        new ImageService("http://example.org/images/book1-page2", ImageApiProfile.LEVEL_ONE);
     imgService.setWidth(6000);
     imgService.setHeight(8000);
     TileInfo tileInfo = new TileInfo(512);
@@ -130,7 +134,8 @@ public class SpecExamplesSerializationTest {
     canvas.setWidth(750);
     canvas.setHeight(1000);
     img = new ImageContent("http://example.org/iiif/book1/res/page3.jpg");
-    img.addService(new ImageService("http://example.org/images/book1-page3", ImageApiProfile.LEVEL_ONE));
+    img.addService(
+        new ImageService("http://example.org/images/book1-page3", ImageApiProfile.LEVEL_ONE));
     img.setWidth(1500);
     img.setHeight(2000);
     canvas.addImage(img);
@@ -142,9 +147,9 @@ public class SpecExamplesSerializationTest {
 
     Range introRange = new Range("http://example.org/iiif/book1/range/r1", "Introduction");
     introRange.addCanvas(
-      seq.getCanvases().get(0).getIdentifier().toString(),
-      seq.getCanvases().get(1).getIdentifier().toString(),
-      seq.getCanvases().get(2).getIdentifier().toString() + "#xywh=0,0,750,300");
+        seq.getCanvases().get(0).getIdentifier().toString(),
+        seq.getCanvases().get(1).getIdentifier().toString(),
+        seq.getCanvases().get(2).getIdentifier().toString() + "#xywh=0,0,750,300");
     manifest.addRange(introRange);
 
     assertSerializationEqualsSpec(manifest, "full_response.json");
@@ -162,7 +167,9 @@ public class SpecExamplesSerializationTest {
 
     Annotation second = new Annotation(Motivation.PAINTING);
     second.setOn(new Canvas("http://example.org/iiif/book1/canvas/p1"));
-    OtherContent secondResource = new OtherContent("http://example.org/iiif/book1/res/tei-text-p1.xml", "application/tei+xml");
+    OtherContent secondResource =
+        new OtherContent(
+            "http://example.org/iiif/book1/res/tei-text-p1.xml", "application/tei+xml");
     secondResource.setType("dctypes:Text");
     second.setResource(secondResource);
 
@@ -174,7 +181,8 @@ public class SpecExamplesSerializationTest {
   public void testAnnotationListWithTranscription() throws Exception {
     AnnotationList annotationList = new AnnotationList("http://example.org/iiif/book1/list/p1");
 
-    Annotation annotation = new Annotation("http://example.org/iiif/book1/annotation/anno1", Motivation.PAINTING);
+    Annotation annotation =
+        new Annotation("http://example.org/iiif/book1/annotation/anno1", Motivation.PAINTING);
     annotation.setOn(new Canvas("http://example.org/iiif/book1/canvas/p1#xywh=100,100,300,300"));
 
     SpecificResource specificResource = new SpecificResource();
@@ -213,13 +221,15 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testAnnotationWithChoice() throws Exception {
-    Annotation anno = new Annotation("http://example.org/iiif/book1/annotation/anno1", Motivation.PAINTING);
+    Annotation anno =
+        new Annotation("http://example.org/iiif/book1/annotation/anno1", Motivation.PAINTING);
     anno.setOn(new Canvas("http://example.org/iiif/book1/canvas/p1"));
     ImageContent color = new ImageContent("http://example.org/iiif/book1/res/page1.jpg");
-    color.setFormat((MimeType) null);  // Spec example doesn't have format, so we skip it
+    color.setFormat((MimeType) null); // Spec example doesn't have format, so we skip it
     color.addLabel("Color");
-    ImageContent blackWhite = new ImageContent("http://example.org/iiif/book1/res/page1-blackandwhite.jpg");
-    blackWhite.setFormat((MimeType) null);  // Spec example doesn't have format, so we skip it
+    ImageContent blackWhite =
+        new ImageContent("http://example.org/iiif/book1/res/page1-blackandwhite.jpg");
+    blackWhite.setFormat((MimeType) null); // Spec example doesn't have format, so we skip it
     blackWhite.addLabel("Black and White");
     color.addAlternative(blackWhite);
     anno.setResource(color);
@@ -234,7 +244,7 @@ public class SpecExamplesSerializationTest {
     canvas.setWidth(750);
     canvas.setHeight(1000);
     ImageContent thumb = new ImageContent("http://example.org/iiif/book1/canvas/p1/thumb.jpg");
-    thumb.setFormat((MimeType) null);  // Spec example doesn't have format, so we skip it
+    thumb.setFormat((MimeType) null); // Spec example doesn't have format, so we skip it
     thumb.setWidth(150);
     thumb.setHeight(200);
     canvas.addThumbnail(thumb);
@@ -245,27 +255,25 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testCollection() throws Exception {
-    Collection coll = new Collection("http://example.org/iiif/collection/top",
-      "Top Level Collection for Example Organization");
+    Collection coll =
+        new Collection(
+            "http://example.org/iiif/collection/top",
+            "Top Level Collection for Example Organization");
     coll.addViewingHint(ViewingHint.TOP);
     coll.addDescription("Description of Collection");
     coll.addAttribution("Provided by Example Organization");
 
     Collection sub1 = new Collection("http://example.org/iiif/collection/sub1", "Sub-Collection 1");
-    Collection subsub1 = new Collection("http://example.org/iiif/collection/part1",
-      "My Multi-volume Set");
+    Collection subsub1 =
+        new Collection("http://example.org/iiif/collection/part1", "My Multi-volume Set");
     subsub1.addViewingHint(ViewingHint.MULTI_PART);
-    Collection subsub3 = new Collection("http://example.org/iiif/collection/part2",
-      "My Sub Collection");
+    Collection subsub3 =
+        new Collection("http://example.org/iiif/collection/part2", "My Sub Collection");
     subsub3.addViewingHint(ViewingHint.INDIVIDUALS);
     sub1.addMember(
-      subsub1,
-      new Manifest("http://example.org/iiif/book1/manifest1", "My Book"),
-      subsub3);
+        subsub1, new Manifest("http://example.org/iiif/book1/manifest1", "My Book"), subsub3);
     coll.addCollection(
-      sub1,
-      new Collection("http://example.org/iiif/collection/part2",
-        "Sub Collection 2"));
+        sub1, new Collection("http://example.org/iiif/collection/part2", "Sub Collection 2"));
     coll.addManifest(new Manifest("http://example.org/iiif/book1/manifest", "Book 1"));
     assertSerializationEqualsSpec(coll, "collection.json");
   }
@@ -282,7 +290,8 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testEmbeddedContent() throws Exception {
-    Annotation anno = new Annotation("http://example.org/iiif/book1/annotation/p1", Motivation.PAINTING);
+    Annotation anno =
+        new Annotation("http://example.org/iiif/book1/annotation/p1", Motivation.PAINTING);
     anno.setOn(new Canvas("http://example.org/iiif/book1/canvas/p1#xywh=100,150,500,25"));
     ContentAsText res = new ContentAsText("Here starts book one...");
     res.setFormat(MimeType.fromTypename("text/plain"));
@@ -293,12 +302,14 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testImageResource() throws Exception {
-    Annotation anno = new Annotation("http://example.org/iiif/book1/annotation/p0001-image", Motivation.PAINTING);
+    Annotation anno =
+        new Annotation("http://example.org/iiif/book1/annotation/p0001-image", Motivation.PAINTING);
     anno.setOn(new Canvas("http://example.org/iiif/book1/canvas/p1"));
     ImageContent img = new ImageContent("http://example.org/iiif/book1/res/page1.jpg");
     img.setWidth(1500);
     img.setHeight(2000);
-    img.addService(new ImageService("http://example.org/images/book1-page1", ImageApiProfile.LEVEL_TWO));
+    img.addService(
+        new ImageService("http://example.org/images/book1-page1", ImageApiProfile.LEVEL_TWO));
     anno.setResource(img);
     assertSerializationEqualsSpec(anno, "imageResource.json");
   }
@@ -312,20 +323,21 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testLayer() throws Exception {
-    Layer layer = new Layer("http://example.org/iiif/book1/layer/transcription",
-      "Diplomatic Transcription");
+    Layer layer =
+        new Layer("http://example.org/iiif/book1/layer/transcription", "Diplomatic Transcription");
     layer.addOtherContent(
-      "http://example.org/iiif/book1/list/l1",
-      "http://example.org/iiif/book1/list/l2",
-      "http://example.org/iiif/book1/list/l3",
-      "http://example.org/iiif/book1/list/l4");
+        "http://example.org/iiif/book1/list/l1",
+        "http://example.org/iiif/book1/list/l2",
+        "http://example.org/iiif/book1/list/l3",
+        "http://example.org/iiif/book1/list/l4");
     assertSerializationEqualsSpec(layer, "layer.json");
   }
 
   @Test
   public void testManifest() throws Exception {
     Manifest manifest = new Manifest("http://example.org/iiif/book1/manifest", "Book 1");
-    manifest.addDescription("A longer description of this example book. It should give some real information.");
+    manifest.addDescription(
+        "A longer description of this example book. It should give some real information.");
 
     manifest.addMetadata("Author", "Anne Author");
     PropertyValue multiLangValue = new PropertyValue();
@@ -335,10 +347,14 @@ public class SpecExamplesSerializationTest {
     PropertyValue multiValue = new PropertyValue();
     multiValue.addValue("Text of note 1", "Text of note 2");
     manifest.addMetadata(new MetadataEntry(new PropertyValue("Notes"), multiValue));
-    manifest.addMetadata("Source", "<span>From: <a href=\"http://example.org/db/1.html\">Some Collection</a></span>");
+    manifest.addMetadata(
+        "Source",
+        "<span>From: <a href=\"http://example.org/db/1.html\">Some Collection</a></span>");
 
-    ImageContent thumb = new ImageContent("http://example.org/images/book1-page1/full/80,100/0/default.jpg");
-    thumb.addService(new ImageService("http://example.org/images/book1-page1", ImageApiProfile.LEVEL_ONE));
+    ImageContent thumb =
+        new ImageContent("http://example.org/images/book1-page1/full/80,100/0/default.jpg");
+    thumb.addService(
+        new ImageService("http://example.org/images/book1-page1", ImageApiProfile.LEVEL_ONE));
     thumb.setFormat((MimeType) null);
     manifest.addThumbnail(thumb);
 
@@ -350,20 +366,30 @@ public class SpecExamplesSerializationTest {
     manifest.addAttribution("Provided by Example Organization");
 
     ImageContent logo = new ImageContent("http://example.org/logos/institution1.jpg");
-    logo.addService(new ImageService("http://example.org/service/inst1", ImageApiProfile.LEVEL_TWO));
+    logo.addService(
+        new ImageService("http://example.org/service/inst1", ImageApiProfile.LEVEL_TWO));
     logo.setFormat((MimeType) null);
     manifest.addLogo(logo);
 
     manifest.addRelated(new OtherContent("http://example.org/videos/video-book1.mpg"));
-    manifest.addService(new GenericService("http://example.org/ns/jsonld/context.json", "http://example.org/service/example", "http://example.org/docs/example-service.html"));
-    manifest.addSeeAlso(new OtherContent("http://example.org/library/catalog/book1.xml", "text/xml", "http://example.org/profiles/bibliographic"));
+    manifest.addService(
+        new GenericService(
+            "http://example.org/ns/jsonld/context.json",
+            "http://example.org/service/example",
+            "http://example.org/docs/example-service.html"));
+    manifest.addSeeAlso(
+        new OtherContent(
+            "http://example.org/library/catalog/book1.xml",
+            "text/xml",
+            "http://example.org/profiles/bibliographic"));
     // FIXME: "text/xml" does not seem to be supported by our Mime class, so we set it manually
 
     OtherContent pdfRendering = new OtherContent("http://example.org/iiif/book1.pdf");
     pdfRendering.addLabel("Download as PDF");
     manifest.addRendering(pdfRendering);
 
-    manifest.addSequence(new Sequence("http://example.org/iiif/book1/sequence/normal", "Current Page Order"));
+    manifest.addSequence(
+        new Sequence("http://example.org/iiif/book1/sequence/normal", "Current Page Order"));
     manifest.addWithin(new Collection("http://example.org/collections/books/"));
 
     assertSerializationEqualsSpec(manifest, "manifest.json");
@@ -377,16 +403,16 @@ public class SpecExamplesSerializationTest {
     Range memberRange = new Range("http://example.org/iiif/book1/range/r1", "Introduction");
     memberRange.setContentLayer("http://example.org/iiif/book1/layer/introTexts");
     tocRange.addMember(
-      new Canvas("http://example.org/iiif/book1/canvas/cover", "Front Cover"),
-      memberRange,
-      new Canvas("http://example.org/iiif/book1/canvas/backCover", "Back Cover"));
+        new Canvas("http://example.org/iiif/book1/canvas/cover", "Front Cover"),
+        memberRange,
+        new Canvas("http://example.org/iiif/book1/canvas/backCover", "Back Cover"));
 
     Range canvasRange = new Range("http://example.org/iiif/book1/range/r1", "Introduction");
     canvasRange.addRange("http://example.org/iiif/book1/range/r1-1");
     canvasRange.addCanvas(
-      "http://example.org/iiif/book1/canvas/p1",
-      "http://example.org/iiif/book1/canvas/p2",
-      "http://example.org/iiif/book1/canvas/p3#xywh=0,0,750,300");
+        "http://example.org/iiif/book1/canvas/p1",
+        "http://example.org/iiif/book1/canvas/p2",
+        "http://example.org/iiif/book1/canvas/p3#xywh=0,0,750,300");
 
     Range lastRange = new Range("http://example.org/iiif/book1/range/r1-1", "Objectives and Scope");
     lastRange.addCanvas("http://example.org/iiif/book1/canvas/p2#xywh=0,0,500,500");
@@ -399,7 +425,8 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testPagedCollection() throws Exception {
-    Collection coll = new Collection("http://example.org/iiif/collection/top", "Example Big Collection");
+    Collection coll =
+        new Collection("http://example.org/iiif/collection/top", "Example Big Collection");
     coll.setTotal(9316290);
     coll.setFirst(new Collection("http://example.org/iiif/collection/c1"));
     assertSerializationEqualsSpec(coll, "pagedCollection.json");
@@ -407,7 +434,9 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testPagedLayer() throws Exception {
-    Layer layer = new Layer("http://example.org/iiif/book1/layer/transcription", "Example Long Transcription");
+    Layer layer =
+        new Layer(
+            "http://example.org/iiif/book1/layer/transcription", "Example Long Transcription");
     layer.setTotal(496923);
     layer.setFirst(new AnnotationList("http://example.org/iiif/book1/list/l1"));
     assertSerializationEqualsSpec(layer, "pagedLayer.json");
@@ -415,25 +444,31 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testSequence() throws Exception {
-    Sequence seq = new Sequence("http://example.org/iiif/book1/sequence/normal", "Current Page Order");
+    Sequence seq =
+        new Sequence("http://example.org/iiif/book1/sequence/normal", "Current Page Order");
     seq.setViewingDirection(ViewingDirection.LEFT_TO_RIGHT);
     seq.addViewingHint(ViewingHint.PAGED);
     seq.setStartCanvas(URI.create("http://example.org/iiif/book1/canvas/p2"));
 
     seq.addCanvas(
-      new Canvas("http://example.org/iiif/book1/canvas/p1", "p. 1"),
-      new Canvas("http://example.org/iiif/book1/canvas/p2", "p. 2"),
-      new Canvas("http://example.org/iiif/book1/canvas/p3", "p. 3"));
+        new Canvas("http://example.org/iiif/book1/canvas/p1", "p. 1"),
+        new Canvas("http://example.org/iiif/book1/canvas/p2", "p. 2"),
+        new Canvas("http://example.org/iiif/book1/canvas/p3", "p. 3"));
     assertSerializationEqualsSpec(seq, "sequence.json");
   }
 
   @Test
   public void testSpecificResourceAnnotation() throws Exception {
-    Annotation anno = new Annotation("http://example.org/iiif/book1/annotation/anno1", Motivation.PAINTING);
+    Annotation anno =
+        new Annotation("http://example.org/iiif/book1/annotation/anno1", Motivation.PAINTING);
     anno.setOn(new Canvas("http://www.example.org/iiif/book1/canvas/p1#xywh=0,0,600,900"));
-    SpecificResource res = new SpecificResource("http://www.example.org/iiif/book1-page1/50,50,1250,1850/full/0/default.jpg");
-    ImageContent full = new ImageContent("http://example.org/iiif/book1-page1/full/full/0/default.jpg");
-    full.addService(new ImageService("http://example.org/iiif/book1-page1", ImageApiProfile.LEVEL_TWO));
+    SpecificResource res =
+        new SpecificResource(
+            "http://www.example.org/iiif/book1-page1/50,50,1250,1850/full/0/default.jpg");
+    ImageContent full =
+        new ImageContent("http://example.org/iiif/book1-page1/full/full/0/default.jpg");
+    full.addService(
+        new ImageService("http://example.org/iiif/book1-page1", ImageApiProfile.LEVEL_TWO));
     full.setFormat((MimeType) null);
     res.setFull(full);
     ImageApiSelector selector = new ImageApiSelector();
@@ -445,7 +480,8 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testStylesheet() throws Exception {
-    Annotation anno = new Annotation("http://example.org/iiif/book1/annotation/anno1", Motivation.PAINTING);
+    Annotation anno =
+        new Annotation("http://example.org/iiif/book1/annotation/anno1", Motivation.PAINTING);
     anno.setOn(new Canvas("http://example.org/iiif/book1/canvas/p1#xywh=100,150,500,30"));
     anno.setStylesheet(new CssStyle(".red {color: red;}"));
     SpecificResource res = new SpecificResource();
@@ -457,7 +493,8 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testSvgSelector() throws Exception {
-    Annotation anno = new Annotation("http://example.org/iiif/book1/annotation/anno1", Motivation.PAINTING);
+    Annotation anno =
+        new Annotation("http://example.org/iiif/book1/annotation/anno1", Motivation.PAINTING);
     anno.setOn(new Canvas("http://example.org/iiif/book1/canvas/p1#xywh=100,100,300,300"));
     SpecificResource res = new SpecificResource();
     res.setFull(new ImageContent("http://example.org/iiif/book1/res/page1.jpg"));

--- a/src/test/java/de/digitalcollections/iiif/model/search/SpecExamplesDeserializationTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/search/SpecExamplesDeserializationTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.model.search;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import de.digitalcollections.iiif.model.jackson.IiifObjectMapper;
@@ -15,8 +17,6 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class SpecExamplesDeserializationTest {
 
   private ObjectMapper mapper;
@@ -27,32 +27,30 @@ public class SpecExamplesDeserializationTest {
   }
 
   private <T> T readFromResources(String filename, Class<T> clz) throws IOException {
-    return mapper.readValue(
-      Resources.getResource("spec/search/" + filename), clz);
+    return mapper.readValue(Resources.getResource("spec/search/" + filename), clz);
   }
 
   @Test
   public void testAutocomplete() throws Exception {
-    ContentSearchService service = readFromResources("autocomplete.json", ContentSearchService.class);
+    ContentSearchService service =
+        readFromResources("autocomplete.json", ContentSearchService.class);
     assertThat(service.getIdentifier().toString())
-      .isEqualTo("http://example.org/services/identifier/search");
-    assertThat(service.getAutocompleteService())
-      .isInstanceOf(AutocompleteService.class);
+        .isEqualTo("http://example.org/services/identifier/search");
+    assertThat(service.getAutocompleteService()).isInstanceOf(AutocompleteService.class);
     assertThat(service.getAutocompleteService().getIdentifier().toString())
-      .isEqualTo("http://example.org/services/identifier/autocomplete");
+        .isEqualTo("http://example.org/services/identifier/autocomplete");
   }
 
   @Test
   public void testBasicSearch() throws Exception {
     SearchResult result = readFromResources("basicSearch.json", SearchResult.class);
-    assertThat(result.getContext())
-      .containsExactly(Resource.CONTEXT, SearchResult.CONTEXT);
+    assertThat(result.getContext()).containsExactly(Resource.CONTEXT, SearchResult.CONTEXT);
     assertThat(result.getResources()).hasSize(1);
     assertThat(result.getHits()).hasSize(1);
     SearchHit hit = result.getHits().get(0);
     assertThat(hit.getAnnotations()).hasSize(1);
     assertThat(hit.getAnnotations().get(0).getIdentifier().toString())
-      .isEqualTo("http://example.org/identifier/annotation/anno1");
+        .isEqualTo("http://example.org/identifier/annotation/anno1");
   }
 
   @Test
@@ -61,16 +59,17 @@ public class SpecExamplesDeserializationTest {
     assertThat(terms.getIgnored()).containsExactly("user");
     assertThat(terms.getTerms()).hasSize(4);
     assertThat(terms.getTerms().get(0))
-      .hasFieldOrPropertyWithValue("match", "bird")
-      .hasFieldOrPropertyWithValue("url", URI.create("http://example.org/service/identifier/search?motivation=painting&q=bird"))
-      .hasFieldOrPropertyWithValue("count", 15);
+        .hasFieldOrPropertyWithValue("match", "bird")
+        .hasFieldOrPropertyWithValue(
+            "url",
+            URI.create("http://example.org/service/identifier/search?motivation=painting&q=bird"))
+        .hasFieldOrPropertyWithValue("count", 15);
   }
 
   @Test
   public void testFullResponseWithLabels() throws Exception {
     TermList terms = readFromResources("fullResponseWithLabels.json", TermList.class);
-    assertThat(terms.getTerms().stream().map(Term::getLabelString))
-      .containsExactly("bird", "biro");
+    assertThat(terms.getTerms().stream().map(Term::getLabelString)).containsExactly("bird", "biro");
   }
 
   @Test
@@ -78,57 +77,55 @@ public class SpecExamplesDeserializationTest {
     SearchResult result = readFromResources("highlighting.json", SearchResult.class);
     assertThat(result.getResources()).hasSize(1);
     Annotation anno = result.getResources().get(0);
-    assertThat(anno.getResource())
-      .isInstanceOf(ContentAsText.class);
+    assertThat(anno.getResource()).isInstanceOf(ContentAsText.class);
     assertThat(((ContentAsText) anno.getResource()).getChars())
-      .isEqualTo("There are two birds in the bush.");
+        .isEqualTo("There are two birds in the bush.");
     assertThat(result.getHits()).hasSize(1);
     SearchHit hit = result.getHits().get(0);
     assertThat(hit.getAnnotations()).hasSize(1);
-    assertThat(hit.getAnnotations().get(0).getIdentifier())
-      .isEqualTo(anno.getIdentifier());
+    assertThat(hit.getAnnotations().get(0).getIdentifier()).isEqualTo(anno.getIdentifier());
 
     assertThat(hit.getSelectors()).hasSize(2);
     assertThat(hit.getSelectors().get(0))
-      .hasFieldOrPropertyWithValue("exact", "birds")
-      .hasFieldOrPropertyWithValue("prefix", "There are two ")
-      .hasFieldOrPropertyWithValue("suffix", " in the bush");
+        .hasFieldOrPropertyWithValue("exact", "birds")
+        .hasFieldOrPropertyWithValue("prefix", "There are two ")
+        .hasFieldOrPropertyWithValue("suffix", " in the bush");
     assertThat(hit.getSelectors().get(1))
-      .hasFieldOrPropertyWithValue("exact", "bush")
-      .hasFieldOrPropertyWithValue("prefix", "two birds in the ")
-      .hasFieldOrPropertyWithValue("suffix", ".");
+        .hasFieldOrPropertyWithValue("exact", "bush")
+        .hasFieldOrPropertyWithValue("prefix", "two birds in the ")
+        .hasFieldOrPropertyWithValue("suffix", ".");
   }
 
   @Test
   public void testMultiAnnotationHits() throws Exception {
     SearchResult result = readFromResources("multiAnnotationHits.json", SearchResult.class);
     assertThat(result.getResources()).hasSize(2);
-    assertThat(result.getResources().get(0).getOn())
-      .isInstanceOf(Canvas.class);
-    assertThat(result.getResources().get(1).getResource())
-      .isInstanceOf(ContentAsText.class);
+    assertThat(result.getResources().get(0).getOn()).isInstanceOf(Canvas.class);
+    assertThat(result.getResources().get(1).getResource()).isInstanceOf(ContentAsText.class);
     assertThat(((ContentAsText) result.getResources().get(1).getResource()).getChars())
-      .isEqualTo("is worth two in the bush");
+        .isEqualTo("is worth two in the bush");
     assertThat(result.getHits()).hasSize(1);
     SearchHit hit = result.getHits().get(0);
     assertThat(hit.getAnnotations().stream().map(Resource::getIdentifier))
-      .containsExactlyElementsOf(result.getResources().stream().map(Resource::getIdentifier).collect(Collectors.toList()));
+        .containsExactlyElementsOf(
+            result.getResources().stream()
+                .map(Resource::getIdentifier)
+                .collect(Collectors.toList()));
   }
 
   @Test
   public void testSnippets() throws Exception {
     SearchResult result = readFromResources("snippets.json", SearchResult.class);
     assertThat(result.getResources()).hasSize(1);
-    assertThat(result.getResources().get(0).getResource())
-      .isInstanceOf(ContentAsText.class);
+    assertThat(result.getResources().get(0).getResource()).isInstanceOf(ContentAsText.class);
     assertThat(((ContentAsText) result.getResources().get(0).getResource()).getChars())
-      .isEqualTo("birds");
+        .isEqualTo("birds");
 
     assertThat(result.getHits()).hasSize(1);
     assertThat(result.getHits().get(0).getAnnotations()).hasSize(1);
     assertThat(result.getHits().get(0))
-      .hasFieldOrPropertyWithValue("before", "There are two ")
-      .hasFieldOrPropertyWithValue("after", " in the bush");
+        .hasFieldOrPropertyWithValue("before", "There are two ")
+        .hasFieldOrPropertyWithValue("after", " in the bush");
   }
 
   @Test
@@ -137,11 +134,10 @@ public class SpecExamplesDeserializationTest {
     assertThat(list.getResources()).hasSize(1);
     Annotation anno = list.getResources().get(0);
     assertThat(((ContentAsText) anno.getResource()).getChars())
-      .isEqualTo("A bird in the hand is worth two in the bush");
+        .isEqualTo("A bird in the hand is worth two in the bush");
     assertThat(anno.getOn()).isInstanceOf(Canvas.class);
     assertThat(anno.getOn().getWithin().get(0)).isInstanceOf(Manifest.class);
-    assertThat(anno.getOn().getWithin().get(0).getLabelString())
-      .isEqualTo("Example Manifest");
+    assertThat(anno.getOn().getWithin().get(0).getLabelString()).isEqualTo("Example Manifest");
   }
 
   @Test

--- a/src/test/java/de/digitalcollections/iiif/model/search/SpecExamplesSerializationTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/search/SpecExamplesSerializationTest.java
@@ -28,10 +28,11 @@ public class SpecExamplesSerializationTest {
 
   private String readFromResources(String filename) throws IOException {
     return Resources.toString(
-      Resources.getResource("spec/search/" + filename), Charset.defaultCharset());
+        Resources.getResource("spec/search/" + filename), Charset.defaultCharset());
   }
 
-  private void assertSerializationEqualsSpec(Object obj, String specFilename) throws IOException, JSONException {
+  private void assertSerializationEqualsSpec(Object obj, String specFilename)
+      throws IOException, JSONException {
     String specJson = readFromResources(specFilename);
     String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
     JSONAssert.assertEquals(specJson, json, true);
@@ -39,14 +40,16 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testAutocomplete() throws Exception {
-    ContentSearchService service = new ContentSearchService("http://example.org/services/identifier/search");
+    ContentSearchService service =
+        new ContentSearchService("http://example.org/services/identifier/search");
     service.setAutocompleteServiceFromId("http://example.org/services/identifier/autocomplete");
     assertSerializationEqualsSpec(service, "autocomplete.json");
   }
 
   @Test
   public void testBasicSearch() throws Exception {
-    SearchResult result = new SearchResult("http://example.org/service/manifest/search?q=bird&page=1");
+    SearchResult result =
+        new SearchResult("http://example.org/service/manifest/search?q=bird&page=1");
     result.addResource(new Annotation("http://example.org/identifier/annotation/anno1"));
     SearchHit hit = new SearchHit();
     hit.addAnnotation(new Annotation("http://example.org/identifier/annotation/anno1"));
@@ -56,31 +59,46 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testFullResponse() throws Exception {
-    TermList terms = new TermList("http://example.org/service/identifier/autocomplete?q=bir&motivation=painting");
+    TermList terms =
+        new TermList(
+            "http://example.org/service/identifier/autocomplete?q=bir&motivation=painting");
     terms.addIgnored("user");
     terms.addTerm(
-      new Term("http://example.org/service/identifier/search?motivation=painting&q=bird", "bird", 15),
-      new Term("http://example.org/service/identifier/search?motivation=painting&q=biro", "biro", 3),
-      new Term("http://example.org/service/identifier/search?motivation=painting&q=birth", "birth", 9),
-      new Term("http://example.org/service/identifier/search?motivation=painting&q=birthday", "birthday", 21));
+        new Term(
+            "http://example.org/service/identifier/search?motivation=painting&q=bird", "bird", 15),
+        new Term(
+            "http://example.org/service/identifier/search?motivation=painting&q=biro", "biro", 3),
+        new Term(
+            "http://example.org/service/identifier/search?motivation=painting&q=birth", "birth", 9),
+        new Term(
+            "http://example.org/service/identifier/search?motivation=painting&q=birthday",
+            "birthday",
+            21));
     assertSerializationEqualsSpec(terms, "fullResponse.json");
   }
 
   @Test
   public void testFullResponseWithLabels() throws Exception {
-    TermList terms = new TermList("http://example.org/service/identifier/autocomplete?q=http%3A%2F%2Fsemtag.example.org%2Ftag%2Fb&motivation=tagging");
+    TermList terms =
+        new TermList(
+            "http://example.org/service/identifier/autocomplete?q=http%3A%2F%2Fsemtag.example.org%2Ftag%2Fb&motivation=tagging");
     terms.addIgnored("user");
     terms.addTerm(
-      new Term("http://example.org/service/identifier/autocomplete?motivation=tagging&q=http%3A%2F%2Fsemtag.example.org%2Ftag%2Fbird", "http://semtag.example.org/tag/bird", 15, "bird"),
-      new Term("http://example.org/service/identifier/autocomplete?motivation=tagging&q=http%3A%2F%2Fsemtag.example.org%2Ftag%2Fbiro", "http://semtag.example.org/tag/biro", 3, "biro"));
+        new Term(
+            "http://example.org/service/identifier/autocomplete?motivation=tagging&q=http%3A%2F%2Fsemtag.example.org%2Ftag%2Fbird",
+            "http://semtag.example.org/tag/bird", 15, "bird"),
+        new Term(
+            "http://example.org/service/identifier/autocomplete?motivation=tagging&q=http%3A%2F%2Fsemtag.example.org%2Ftag%2Fbiro",
+            "http://semtag.example.org/tag/biro", 3, "biro"));
     assertSerializationEqualsSpec(terms, "fullResponseWithLabels.json");
   }
 
   @Test
   public void testHighlighting() throws Exception {
-    SearchResult result = new SearchResult("http://example.org/service/manifest/search?q=b*&page=1");
-    Annotation anno = new Annotation("http://example.org/identifier/annotation/anno-line",
-      Motivation.PAINTING);
+    SearchResult result =
+        new SearchResult("http://example.org/service/manifest/search?q=b*&page=1");
+    Annotation anno =
+        new Annotation("http://example.org/identifier/annotation/anno-line", Motivation.PAINTING);
     anno.setOn(new Canvas("http://example.org/identifier/canvas1#xywh=200,100,40,20"));
     anno.setResource(new ContentAsText("There are two birds in the bush."));
     result.addResource(anno);
@@ -88,8 +106,8 @@ public class SpecExamplesSerializationTest {
     SearchHit hit = new SearchHit();
     hit.addAnnotation(new Annotation(anno.getIdentifier().toString()));
     hit.addSelector(
-      new TextQuoteSelector("birds", "There are two ", " in the bush"),
-      new TextQuoteSelector("bush", "two birds in the ", "."));
+        new TextQuoteSelector("birds", "There are two ", " in the bush"),
+        new TextQuoteSelector("bush", "two birds in the ", "."));
     result.addHit(hit);
     assertSerializationEqualsSpec(result, "highlighting.json");
   }
@@ -97,19 +115,20 @@ public class SpecExamplesSerializationTest {
   @Test
   public void testMultiAnnotationHits() throws Exception {
     SearchResult result = new SearchResult("http://example.org/service/manifest/search?q=hand+is");
-    Annotation anno1 = new Annotation("http://example.org/identifier/annotation/anno-bird",
-      Motivation.PAINTING);
+    Annotation anno1 =
+        new Annotation("http://example.org/identifier/annotation/anno-bird", Motivation.PAINTING);
     anno1.setResource(new ContentAsText("A bird in the hand"));
     anno1.setOn(new Canvas("http://example.org/identifier/canvas1#xywh=200,100,150,30"));
-    Annotation anno2 = new Annotation("http://example.org/identifier/annotation/anno-are",
-      Motivation.PAINTING);
+    Annotation anno2 =
+        new Annotation("http://example.org/identifier/annotation/anno-are", Motivation.PAINTING);
     anno2.setResource(new ContentAsText("is worth two in the bush"));
     anno2.setOn(new Canvas("http://example.org/identifier/canvas1#xywh=200,140,170,30"));
     result.addResource(anno1, anno2);
 
     SearchHit hit = new SearchHit();
-    hit.addAnnotation(new Annotation(anno1.getIdentifier().toString()),
-      new Annotation(anno2.getIdentifier().toString()));
+    hit.addAnnotation(
+        new Annotation(anno1.getIdentifier().toString()),
+        new Annotation(anno2.getIdentifier().toString()));
     hit.setMatch("hand is");
     hit.setBefore("A bird in the ");
     hit.setAfter(" worth two in the bush");
@@ -120,9 +139,10 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testComplexTargetResource() throws Exception {
-    AnnotationList annos = new AnnotationList("http://example.org/service/manifest/search?q=bird&motivation=painting");
-    Annotation anno = new Annotation("http://example.org/identifier/annotation/anno-line",
-      Motivation.PAINTING);
+    AnnotationList annos =
+        new AnnotationList("http://example.org/service/manifest/search?q=bird&motivation=painting");
+    Annotation anno =
+        new Annotation("http://example.org/identifier/annotation/anno-line", Motivation.PAINTING);
     anno.setResource(new ContentAsText("A bird in the hand is worth two in the bush"));
 
     Canvas target = new Canvas("http://example.org/identifier/canvas1#xywh=100,100,250,20");
@@ -134,7 +154,8 @@ public class SpecExamplesSerializationTest {
 
   @Test
   public void testWithIgnored() throws Exception {
-    SearchResult result = new SearchResult("http://example.org/service/manifest/search?q=bird&page=1");
+    SearchResult result =
+        new SearchResult("http://example.org/service/manifest/search?q=bird&page=1");
     SearchLayer layer = new SearchLayer();
     layer.setTotal(125);
     layer.addIgnored("user");


### PR DESCRIPTION
This MR replaces checkstyle with a maven-plugin that automatically reformats the code to conform with the Google Java Style Guide during the format execution goal, which is executed during the standard clean install and clean test targets.