### PR TITLE
Fix ResourceSerializer performance problem (fixes #62)

### DIFF
--- a/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/ResourceSerializer.java
+++ b/src/main/java/de/digitalcollections/iiif/model/jackson/serialization/ResourceSerializer.java
@@ -107,7 +107,7 @@ public class ResourceSerializer extends JsonSerializer<Resource> {
         break;
       case ID_ONLY:
         // Resources with only an identifier should be a string
-        gen.writeObject(value.getIdentifier().toString());
+        gen.writeString(value.getIdentifier().toString());
         break;
       default:
         // Otherwise delegate to default serializer


### PR DESCRIPTION
This replaces a Jackson `writeObject` call with `writeString`, which should fix performance under some circumstances. See #62 for more details/discussion.