### PR TITLE
Enable custom Quality in the model

### DIFF
--- a/src/main/java/de/digitalcollections/iiif/model/image/ImageApiProfile.java
+++ b/src/main/java/de/digitalcollections/iiif/model/image/ImageApiProfile.java
@@ -63,7 +63,12 @@ public class ImageApiProfile extends Profile {
       GRAY,
       BITONAL,
       DEFAULT,
-      OTHER
+      OTHER;
+
+      @Override
+      public String toString() {
+        return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, this.name());
+      }
     }
 
     /** The image is returned with all of its color information. */
@@ -88,7 +93,7 @@ public class ImageApiProfile extends Profile {
 
     @JsonCreator
     public Quality(String qualityName) {
-      if (!Enums.getIfPresent(ImageApiQuality.class, qualityName).isPresent()) {
+      if (!Enums.getIfPresent(ImageApiQuality.class, qualityName.toUpperCase()).isPresent()) {
         this.imageApiQuality = ImageApiQuality.OTHER;
         this.customQuality = qualityName.toUpperCase();
       } else {
@@ -102,9 +107,9 @@ public class ImageApiProfile extends Profile {
     @Override
     public String toString() {
       if (this.imageApiQuality == ImageApiQuality.OTHER) {
-        return this.customQuality.toString();
+        return this.customQuality.toLowerCase();
       } else {
-        return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, this.imageApiQuality.name());
+        return this.imageApiQuality.toString();
       }
     }
 


### PR DESCRIPTION
This is just intended to start a discussion, since I haven't build anything based on this change yet.

The general idea is to provide a mechanism to supply custom qualities using `hymir`, I've looked into several other IIIF Image server implementations and created some issues describing use cases and an existing implementation:
* [Cantaloupe](https://github.com/cantaloupe-project/cantaloupe/issues/545)
* [Loris](https://github.com/loris-imageserver/loris/issues/546)

Since Hymir seems to be the most hackable of those in the moment I decided to give it a go. This is the first step: enhancing the model.