### PR TITLE
Fix java17 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
+name: CI
+
 on:
-  push:
-    branches: [ main ]
   pull_request:
+    branches: [ main ]
+  push:
     branches: [ main ]
 
 jobs:
@@ -9,14 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 14]
+        java: [11, 17]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          check-latest: true
+          distribution: temurin
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         env:
           cache-name: cache-maven-artifacts
         with:
@@ -29,15 +33,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          check-latest: true
+          distribution: temurin
           java-version: 11
           server-id: ossrh-snapshots
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         env:
           cache-name: cache-maven-artifacts
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
   </scm>
 
   <properties>
-    <java.version>1.8</java.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -71,7 +70,7 @@
     <!-- plugins -->
     <version.jacoco-maven-plugin>0.8.8</version.jacoco-maven-plugin>
     <version.maven-compiler-plugin>3.11.0</version.maven-compiler-plugin>
-    <version.maven-fmt-plugin>2.13</version.maven-fmt-plugin>
+    <version.maven-fmt-plugin>2.19</version.maven-fmt-plugin>
     <version.maven-gpg-plugin>3.0.1</version.maven-gpg-plugin>
     <version.maven-javadoc-plugin>3.5.0</version.maven-javadoc-plugin>
     <version.maven-source-plugin>3.2.1</version.maven-source-plugin>
@@ -156,36 +155,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.coveo</groupId>
+        <groupId>com.spotify.fmt</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
         <version>${version.maven-fmt-plugin}</version>
         <executions>
           <execution>
             <goals>
               <goal>format</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>${version.spotbugs-maven-plugin}</version>
-        <dependencies>
-          <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
-          <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs</artifactId>
-            <version>${version.spotbugs}</version>
-          </dependency>
-        </dependencies>
-        <configuration>
-          <failOnError>false</failOnError>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
             </goals>
           </execution>
         </executions>

--- a/src/test/java/de/digitalcollections/iiif/model/JsonMappingTest.java
+++ b/src/test/java/de/digitalcollections/iiif/model/JsonMappingTest.java
@@ -111,7 +111,17 @@ public class JsonMappingTest {
         .hasSize(1);
 
     Canvas parsedCanvas = mapper.readValue(json, Canvas.class);
-    assertThat(parsedCanvas).isEqualToComparingFieldByFieldRecursively(canvas);
+
+    assertThat(parsedCanvas).usingRecursiveComparison().isEqualTo(canvas);
+
+    // Add some new metadata, which was not serialized
+    canvas.addMetadata("Nothing", "Special");
+
+    // Now it is no longer equal
+    assertThat(parsedCanvas).usingRecursiveComparison().isNotEqualTo(canvas);
+
+    // But when ignoring metadata field, they are equal
+    assertThat(parsedCanvas).usingRecursiveComparison().ignoringFields("metadata").isEqualTo(canvas);
   }
 
   @Test


### PR DESCRIPTION
Hi,

this PR introduces following changes:

* Remove unused Java version info in pom
* Update org of Formatter plugin
* Remove Spotbugs Plugin
* No longer use deprecated `isEqualToComparingFieldByFieldRecursively()`  (see [here](https://assertj.github.io/doc/#assertj-core-recursive-comparison)) as it was no longer working with Java 17 (due to missing getter)
* Update GitHub CI (builds are done with Java 11 and 17)